### PR TITLE
Adds Support For Reading Leverage Farm LP Information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "anchor-attribute-access-control"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed70c97998752288ce9840ae05dac6f7922856624d83bd8706941c363df5aa75"
+checksum = "a9b75d05b6b4ac9d95bb6e3b786b27d3a708c4c5a87c92ffaa25bbe9ae4c5d91"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-account"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7325a9ddeab60ace310dd920b354a6318d31b4dd6d8172a518de3b8d58601035"
+checksum = "485351a6d8157750d10d88c8e256f1bf8339262b2220ae9125aed3471309b5de"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-constant"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfe53dec5dfe5742d949e7c21a3b813296c274183f4fbf669a070e45bd669c9"
+checksum = "dc632c540913dd051a78b00587cc47f57013d303163ddfaf4fa18717f7ccc1e0"
 dependencies = [
  "anchor-syn",
  "proc-macro2 1.0.36",
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-error"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda765864694d1ddeff66e8d97b015760379dc7136474633f7db0ec04577fc8"
+checksum = "3b5bd1dcfa7f3bc22dacef233d70a9e0bee269c4ac484510662f257cba2353a1"
 dependencies = [
  "anchor-syn",
  "proc-macro2 1.0.36",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-event"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab29f55c9bf69f1e9a19838b5630204beaaddc4ca3ab8eed59a637e36b51428"
+checksum = "6c6f9e6ce551ac9a177a45c99a65699a860c9e95fac68675138af1246e2591b0"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-interface"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345ba1c992d29d3b666c4e5c8d8383d3291c4be3795dc13e218d59df55a08c21"
+checksum = "d104aa17418cb329ed7418b227e083d5f326a27f26ce98f5d92e33da62a5f459"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-program"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2fd7fdf8c416d834650e7b8ef1db5746acc74c7333b3d9b3a385f5129e9b522"
+checksum = "b6831b920b173c004ddf7ae1167d1d25e9f002ffcb1773bbc5c7ce532a4441e1"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-state"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5426c71af1fcaa734d2f1dfde0f1e4ccc878be02707c767d6c9e88ef6686ecd5"
+checksum = "cde147b10c71d95dc679785db0b5f3abac0091f789167aa62ac0135e2f54e8b9"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-client"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cf7abbc85e5dc4eddb2c665c894178c1f800850b305e96ce8e19b94a61b754e"
+checksum = "eb1dfd40bbeeb17ff748a0eb9df2d58c70f0e3ac4e11dac08228d3c99ab68976"
 dependencies = [
  "anchor-lang",
  "anyhow",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-accounts"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e597c70258147a5da1ca8801474e3a4a009214c1b7138cd863ef03eeba353a1"
+checksum = "9cde98a0e1a56046b040ff591dfda391f88917af2b6487d02b45093c05be3514"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-lang"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3fab2e8305bfe8971e04e963a442a767d81f8d61e73effdbe04df73bb7f9feb"
+checksum = "a85dd2c5e29e20c7f4701a43724d6cd5406d0ee5694705522e43da0f26542a84"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-spl"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e49a20ac8743546bc76a247ff0a81ceb0cee7653b087ccb330bf3553d907d522"
+checksum = "0188c33b4a3c124c4e593f2b440415aaea70a7650fac6ba0772395385d71c003"
 dependencies = [
  "anchor-lang",
  "solana-program",
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-syn"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68de711b6da0575993b85693d9e075a014de7e66ff4c29e0c38a54376b7d426d"
+checksum = "03549dc2eae0b20beba6333b14520e511822a6321cdb1760f841064a69347316"
 dependencies = [
  "anyhow",
  "bs58 0.3.1",
@@ -904,26 +904,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enum-iterator"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
-dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
 ]
 
 [[package]]
@@ -2446,6 +2426,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
+name = "so-defi-utils"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db1fc804855117156094a4d2bfd2c348f07dfc603ccabe1c1a2798761738731"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ff4c33ccfb0f09e9d8dc459274dc846706d1d08b80e3a2136c243b9cfe6aff"
+checksum = "4312e2b6eb212600119f5246575a9049aaeb863b2ffa41701e8ad659b16bf2e8"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -2480,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92450fee7d018d690e21f26239cf8e792e2dc8e9b69ced308d95af1fa5407624"
+checksum = "3dba0c8fa11ce9758854fb7ee4ab1db38ac0f4cd61825dbab30683d5842fbaa2"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -2500,9 +2490,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0bf764d1df4f0baff3e519a15109970076d07ed3dd8fcb9017084cb2de8c8"
+checksum = "b72a65eace20321fe054c0ca36b490830269e9d5b3a9643f0a250bf29eac742c"
 dependencies = [
  "bv",
  "fnv",
@@ -2519,9 +2509,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831fa3d92a164a04c72756723ab5815c7652e09e961bb604586a0bdfeae3e192"
+checksum = "e2956b561675de11e95cdd0ecdccc6e53917f7971170d6d19a777609d5cacf62"
 dependencies = [
  "fs_extra",
  "log",
@@ -2536,9 +2526,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9246e867f2b095fd0fba7f71dec3e0d008243bbc20fdeb4c7dcc91d5863e537d"
+checksum = "3d1645d8c0e25189cd6bc1f48c98299e6b70be0fc1939b42c369a28d92a71196"
 dependencies = [
  "chrono",
  "clap",
@@ -2554,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36cbdf8761552ed912aa6f2d9b0949d4a90f3a5937735efca173939d38521759"
+checksum = "0a82799271fddf8c62f7f797fd043cff7576408081f8e6185e65a16a687ce59a"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -2568,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f25e846fedd217fb4b72960c0898afd2e6059931ae928829b66148b7d3f750"
+checksum = "a9ae47c64343da3c081ceeee6556d5bf4cf48c63b666e269edcf39ef88c62fd7"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -2602,9 +2592,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b94f780cf5fd63484c47bb53613cff906521155260ebe6780d27f7aeb9e968f"
+checksum = "99e4e8db8d21637b93b49c275d80bd162ef13473dd5aac85603fb80d4ec5fa67"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk",
@@ -2612,9 +2602,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e46f4232ce4b64bd33876f6e46c150a4769b680b88575e2ec7c7170130fafb2"
+checksum = "882f8d75d8720647552cf73f032e8193aeef404bc571463de0b75246e370bfde"
 dependencies = [
  "bincode",
  "chrono",
@@ -2626,9 +2616,9 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc5bc91962786717370e0fc1c4dad9df08a86dc145f6ac386eccffcbaa1799c"
+checksum = "515fc9a743531cda35db13c626773cb735b207c1ad71137bf26d3160b61bd0b9"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2649,9 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94841ed94df9db00ac76a20cf9ca740ee8fb9feb69f6f235531d272a846fa6f"
+checksum = "9b99f4dc52d29f701d1f82e588654c612aceb602169531a4dc2a75c4b010d1e2"
 dependencies = [
  "bs58 0.4.0",
  "bv",
@@ -2669,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0f08a1e285cc66e5675139f022cba2787efe29553b0e6e051737028ae264988"
+checksum = "f54cbe41f73512cf3deed8c97b3510e2ac57e3d565bd0c27ca8a412a6f1ba52e"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.15",
@@ -2681,9 +2671,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fc90ded15ae82e58c4ff0e3b8ac072a4a47905bcd883bfcbfcd2e92545f851"
+checksum = "b2f28d704fed9892c1012303c8600c33e80473bf4d64e234d0fe7a3be4cf5971"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -2692,9 +2682,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c38e8fab4e9f3a41d57ea7a2db76380ef1297c77435e965b26a32680c9b7b4"
+checksum = "9d7353c64879bb1f3249d816621c42f576e5411cba947b0211b395825a3909f8"
 dependencies = [
  "log",
  "solana-sdk",
@@ -2702,9 +2692,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2827548c3e835113220a88a73b17336e3eaa954de9ff52ef20cc70a247aaf962"
+checksum = "4f1ba5b005c49d9b99a0af683472b3c057470c517197b57a0ead1bff7d974c1f"
 dependencies = [
  "env_logger",
  "gethostname",
@@ -2716,9 +2706,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f256c0929936014806234275a5b091416d8f046a42568c8a25b399438bd2f9"
+checksum = "c5a20bfc631cd62d0252076ed25341afe803d949f67e8300291de261826a7dc8"
 dependencies = [
  "bincode",
  "clap",
@@ -2737,9 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0119efd18e1f441ec4c614e0ea6bf719dcaeda6052c721bfe6a0dfd4729dc5ca"
+checksum = "5900b93225b7b70c51131056b1222f1716266ecbdcfbee634021df857eab4c2e"
 dependencies = [
  "ahash",
  "bincode",
@@ -2766,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51abcddafe51821256baa3dcffd01f1a16f830ae86783ba5fa0a7f2f073acbd9"
+checksum = "4f41aee7490ba3d34d05fe778af67ed4e0f996b2e2c9a4999d423f54cf10e116"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -2809,9 +2799,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e1e88c6336c61c0e642d4535f3cca8c2bea9b983fa865d41874433023f77762"
+checksum = "891b653366ece489ac4402a5039399b111174c183821bbb7909da03c50b870ee"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -2833,9 +2823,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961685a0d253ab84b10e65313bb6afb3a499cfe4822f67a3cf488a4b39c2d4a1"
+checksum = "060c7c296a3e4ab98eda24f8cf55856acf0d26294ccb229d6c4b145dc3ba9ca4"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -2843,9 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6ada47918fd2689552d293d7c0f5c8388f62897c6acf59020411132fcdd953"
+checksum = "c6ced6d2b8feb90f16d05148d1b04cab654ea36b2521173c44a5fcb16cd96f27"
 dependencies = [
  "base32",
  "console",
@@ -2864,9 +2854,9 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4c2c02c624393de2610614f9e552fb0cf6607b0ad9053110d7b7fb67099aa7"
+checksum = "84850b8246fc36af40e63486581503de15cb5e26c5339d975ca83a03572e4b9c"
 dependencies = [
  "arrayref",
  "bincode",
@@ -2878,7 +2868,6 @@ dependencies = [
  "crossbeam-channel",
  "dashmap",
  "dir-diff",
- "enum-iterator",
  "flate2",
  "fnv",
  "index_list",
@@ -2920,9 +2909,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a608fdc4ba4cb22c1b05668036f962d7d9bc3e0b72ed5747ab71c754b15f728f"
+checksum = "7d1195be12b957adb491f906e2525f0b9d508a84ff2f089439eac7cae50eca19"
 dependencies = [
  "assert_matches",
  "base64 0.13.0",
@@ -2971,9 +2960,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c10a609f6e77f9c8b888a8baae5075c0d59a98ca606933dcea748d10ffe50bf"
+checksum = "6a3cced778727e460f00a4b29b43a81f484e73c125fa47b6e4d8b311157e0dde"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2 1.0.36",
@@ -2984,9 +2973,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b69cf506f2c75f2afe2b8b022b1ac8d738b9e99a2fc440e33b8c98cc66d2093"
+checksum = "ae8972cd6f0e9552737379e6a5b58fe8e48cda5b6351a271b5cf06072d10d43c"
 dependencies = [
  "bincode",
  "log",
@@ -3007,9 +2996,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2b86b07a83dc3eb631726e90831fe00d60f3a7c28b393e2953852a461918cf"
+checksum = "2dea0844b5e6a526d9b8a5f90a4ac5f1297d59f0d597eebbf605f35bd076ab6a"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -3034,9 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56c21fbc325a112c05ed60cc5dc1afa347fcbe2206243d7165f167ce7f6a3b9"
+checksum = "8710c10180a86fd4f39b9dd4ade32c076f22086793b68f37dc26ca20a16d5f48"
 dependencies = [
  "log",
  "rustc_version",
@@ -3049,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.9.9"
+version = "1.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "536e93c620f691eb64991e0db63520fe35c31d4be08c544fa19cb0c3871b7d91"
+checksum = "f7928f8145abede41a31a2f297c823fc82b81b8951eaa7341ac2d954094df397"
 dependencies = [
  "bincode",
  "log",
@@ -3417,7 +3406,7 @@ dependencies = [
 
 [[package]]
 name = "tulipv2-sdk-common"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "anchor-client",
  "anchor-lang",
@@ -3426,6 +3415,7 @@ dependencies = [
  "bytemuck",
  "num-derive",
  "num-traits",
+ "so-defi-utils",
  "solana-sdk",
  "spl-token",
  "static-pubkey",
@@ -3437,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "tulipv2-sdk-farms"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "anchor-lang",
  "tulip-arrform",
@@ -3445,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "tulipv2-sdk-vaults"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Rust sdk for on-chain (cpi) and off-chain (client-side) usage of Tulip V2 vaults, as well as sparse support for Tulip V1 lending programs.
 
+# V1 Support
+
+Within the `v1` folder you will find a single `tulipv1-sdk` crate, which provides selected functions, accounts, etc... of v1
+
 # Examples
 
 * See [tulipv2-sdk-examples](https://github.com/sol-farm/tulipv2-sdk-examples)

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tulipv2-sdk-common"
-version = "0.9.5"
+version = "0.9.6"
 edition = "2021"
 authors = ["Tulip Protocol"]
 description = "common types, traits, and helper functions used by the v2 sdk"
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/tulipv2-sdk-common"
 readme = "../README.md"
 
 [dependencies]
-anchor-lang = "0.22.0"
-anchor-spl = "0.22.0"
+anchor-lang = "0.24.2"
+anchor-spl = "0.24.2"
 spl-token = "3.2.0"
 tulip-arrform = "0.1.1"
 uint = "0.8"
@@ -19,9 +19,10 @@ num-derive = "0.3"
 num-traits = "0.2"
 thiserror = "1.0"
 static-pubkey = "1.0.2"
-tulipv2-sdk-farms = {path = "../farms", version = "0.9.5"}
+tulipv2-sdk-farms = {path = "../farms", version = "0.9.6"}
 arrayref = "0.3.6"
 bytemuck = "1.7.2"
 solana-sdk = "1.9.1"
+so-defi-utils = "0.1.1"
 [dev-dependencies]
-anchor-client = "0.22.0"
+anchor-client = "0.24.2"

--- a/common/src/lending/leverage_farm.rs
+++ b/common/src/lending/leverage_farm.rs
@@ -1,0 +1,55 @@
+//! accounts involved in leverage farming
+use anchor_lang::solana_program::program_error::ProgramError;
+use anchor_lang::solana_program::pubkey::Pubkey;
+use anchor_lang::solana_program::account_info::AccountInfo;
+
+use crate::DEFAULT_KEY;
+
+/// used to cheap access the lp mint from a given leverage farm using the accessor method.
+/// this is a potentially dangerous method unless sufficient validation of the provided account
+/// is done beforehand
+pub fn get_leverage_farm_lp_mint(
+    account: &AccountInfo,
+) -> std::result::Result<Pubkey, ProgramError> {
+    use so_defi_utils::accessor::{to_pubkey, AccessorType};
+    if account.data_len()-1 < 487 {
+        return Err(ProgramError::AccountDataTooSmall.into());
+    }
+    let data_bytes = AccessorType::Pubkey(488).access(account);
+    if data_bytes.len() != 32 { return Err(ProgramError::InvalidAccountData)};
+    let got_lp_mint = to_pubkey(&data_bytes);
+    if got_lp_mint.eq(&DEFAULT_KEY) { return Err(ProgramError::InvalidAccountData.into())}
+    Ok(got_lp_mint)
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use anchor_client::solana_client::rpc_client::RpcClient;
+    use solana_sdk::account_info::IntoAccountInfo;
+
+    use super::*;
+    #[test]
+    fn test_get_leverage_farm_lp_mint_orca() {
+        let basis_usdc_orca_lev_farm_account = Pubkey::from_str("7dKmQgDoXJ5gBeugwzwXHHE15ypVMBfqffmbJXqnvmcH").unwrap();
+        let want_basis_usdc_orca_lp_mint = Pubkey::from_str("GoaAiajubRgeCFEz9L6mLnSmT2QFegoJDH5tpLfivpj").unwrap();
+        let rpc_client = RpcClient::new("https://ssc-dao.genesysgo.net".to_string());
+        let lev_farm_account = rpc_client.get_account(&basis_usdc_orca_lev_farm_account).unwrap();
+        let mut lev_farm_tuple = (basis_usdc_orca_lev_farm_account, lev_farm_account);
+        let lev_farm_account_info = lev_farm_tuple.into_account_info();
+        let got_lp_mint = get_leverage_farm_lp_mint(&lev_farm_account_info).unwrap();
+        assert_eq!(got_lp_mint, want_basis_usdc_orca_lp_mint);
+    }
+    #[test]
+    fn test_get_leverage_farm_lp_mint_raydium() {
+        let stsol_usdc_ray_lev_farm_account = Pubkey::from_str("2RwEGydvxM7ZuHLgRmKyfve1qYc8ZNsd39BBZtK38CeX").unwrap();
+        let want_stsol_usdc_ray_lp_mint = Pubkey::from_str("HDUJMwYZkjUZre63xUeDhdCi8c6LgUDiBqxmP3QC3VPX").unwrap();
+        let rpc_client = RpcClient::new("https://ssc-dao.genesysgo.net".to_string());
+        let lev_farm_account = rpc_client.get_account(&stsol_usdc_ray_lev_farm_account).unwrap();
+        let mut lev_farm_tuple = (want_stsol_usdc_ray_lp_mint, lev_farm_account);
+        let lev_farm_account_info = lev_farm_tuple.into_account_info();
+        let got_lp_mint = get_leverage_farm_lp_mint(&lev_farm_account_info).unwrap();
+        assert_eq!(got_lp_mint, want_stsol_usdc_ray_lp_mint);
+    }
+}

--- a/common/src/lending/mod.rs
+++ b/common/src/lending/mod.rs
@@ -11,6 +11,14 @@ pub mod last_update;
 pub mod lending_obligation;
 pub mod obligation;
 pub mod reserve;
+pub mod leverage_farm;
+
+use anchor_lang::solana_program::pubkey::Pubkey;
+use anchor_lang::solana_program;
+use static_pubkey::static_pubkey;
+
+pub const ID: Pubkey = static_pubkey!("TLPv2tuSVvn3fSk8RgW3yPddkp5oFivzZV3rA9hQxtX");
+
 
 use crate::math::{common::WAD, decimal::Decimal};
 

--- a/farms/Cargo.toml
+++ b/farms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tulipv2-sdk-farms"
-version = "0.9.5"
+version = "0.9.6"
 edition = "2021"
 authors = ["Tulip Protocol"]
 description = "farm identifiers and farm names used by the v2 sdk"
@@ -10,5 +10,5 @@ documentation = "https://docs.rs/tulipv2-sdk-farms"
 readme = "../README.md"
 
 [dependencies]
-anchor-lang = "0.22.0"
+anchor-lang = "0.24.2"
 tulip-arrform = "0.1.1"

--- a/vaults/Cargo.toml
+++ b/vaults/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tulipv2-sdk-vaults"
-version = "0.9.5"
+version = "0.9.6"
 edition = "2021"
 authors = ["Tulip Protocol"]
 description = "vault account types, and vault instructions used by the v2 sdk"
@@ -16,17 +16,17 @@ staging = []
 production = []
 localnet = []
 [dependencies]
-anchor-lang = "0.22.0"
-anchor-spl = "0.22.0"
+anchor-lang = "0.24.2"
+anchor-spl = "0.24.2"
 spl-token = "3.2.0"
-tulipv2-sdk-common = {path = "../common", version = "0.9.5"}
+tulipv2-sdk-common = {path = "../common", version = "0.9.6"}
 spl-associated-token-account = "1.0.3"
 static-pubkey = "1.0.2"
 type-layout = "0.2.0"
 tulip-arrform = "0.1.1"
 tulip-derivative = "2.2.1"
 itertools = "0.10.3"
-tulipv2-sdk-farms = {path = "../farms", version = "0.9.5"}
+tulipv2-sdk-farms = {path = "../farms", version = "0.9.6"}
 [dev-dependencies]
 proptest = "1.0.0"
 solana-client = "1.9.1"


### PR DESCRIPTION
# Overview

* this updates anchor from 0.22.0 to 0.24.2
* upgrades all crates to  version 0.9.6 
* updates anchor dependencies to 0.24.2
* adds the ability to fetch farm/lp mint associated with a v1 leveraged farm using accessor methods