### PR TITLE
add permissioned shares issuance instruction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,9 +2400,9 @@ dependencies = [
 
 [[package]]
 name = "sighashdb"
-version = "0.1.34"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b58e91b6af83a51250c848b1c676767effd62b6270fa23e1d3341c814ef76f9"
+checksum = "393be469778e092958422c81b8bdacca35b1033caeacbcc72b70a599962cd985"
 
 [[package]]
 name = "signal-hook-registry"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -25,7 +25,7 @@ bytemuck = "1.7.2"
 solana-program = "1.9.13"
 so-defi-utils = "0.1.0"
 spl-associated-token-account = "1.0.3"
-sighashdb = "0.1.33"
+sighashdb = "0.1.37"
 [dev-dependencies]
 anchor-client = "0.24.2"
 

--- a/common/src/config/deposit_tracking/issue_shares.rs
+++ b/common/src/config/deposit_tracking/issue_shares.rs
@@ -16,7 +16,7 @@ use tulipv2_sdk_farms::Farm;
 
 /// object used to bundle together information required by the
 /// `IssueShares` trait
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct DepositAddresses {
     pub authority: Pubkey,
     pub vault: Pubkey,
@@ -29,6 +29,16 @@ pub struct DepositAddresses {
     pub vault_underlying_account: Pubkey,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DepositAddressesPermissioned {
+    pub authority: Pubkey,
+    pub vault: Pubkey,
+    pub vault_pda: Pubkey,
+    pub shares_mint: Pubkey,
+    pub receiving_shares_account: Pubkey,
+    pub depositing_underlying_account: Pubkey,
+    pub vault_underlying_account: Pubkey,
+}
 impl DepositAddresses {
     pub fn new(
         user: Pubkey,
@@ -63,6 +73,35 @@ impl DepositAddresses {
             vault_pda,
             shares_mint,
             receiving_shares_account: deposit_tracking_hold_account,
+            depositing_underlying_account,
+            vault_underlying_account,
+        }
+    }
+}
+
+impl DepositAddressesPermissioned {
+    pub fn new(
+        user: Pubkey,
+        vault: Pubkey,
+        vault_pda: Pubkey,
+        shares_mint: Pubkey,
+        underlying_mint: Pubkey,
+    ) -> DepositAddressesPermissioned {
+        // deposit ata for the user
+        let depositing_underlying_account =
+            spl_associated_token_account::get_associated_token_address(&user, &underlying_mint);
+        let receiving_shares_account = spl_associated_token_account::get_associated_token_address(&user, &shares_mint);
+        let vault_underlying_account = spl_associated_token_account::get_associated_token_address(
+            &vault_pda,
+            &underlying_mint,
+        );
+
+        DepositAddressesPermissioned {
+            authority: user,
+            vault,
+            vault_pda,
+            shares_mint,
+            receiving_shares_account,
             depositing_underlying_account,
             vault_underlying_account,
         }
@@ -134,6 +173,82 @@ impl IssueShares for DepositAddresses {
             AccountMeta::new(self.vault(), false),
             AccountMeta::new(self.deposit_tracking_account(), false),
             AccountMeta::new(self.deposit_tracking_pda(), false),
+            AccountMeta::new_readonly(self.vault_pda(), false),
+            AccountMeta::new(self.vault_underlying_account(), false),
+            AccountMeta::new(self.shares_mint(), false),
+            AccountMeta::new(self.receiving_shares_account(), false),
+            AccountMeta::new(self.depositing_underlying_account(), false),
+            AccountMeta::new_readonly(spl_token::id(), false),
+        ]
+    }
+}
+
+
+
+impl IssueShares for DepositAddressesPermissioned {
+    fn authority(&self) -> Pubkey {
+        self.authority
+    }
+    fn vault(&self) -> Pubkey {
+        self.vault
+    }
+    fn deposit_tracking_account(&self) -> Pubkey {
+        unimplemented!("not used for permissioned deposit")
+    }
+    fn deposit_tracking_pda(&self) -> Pubkey {
+        unimplemented!("not used for permissioned deposit")
+    }
+    fn vault_pda(&self) -> Pubkey {
+        self.vault_pda
+    }
+    fn shares_mint(&self) -> Pubkey {
+        self.shares_mint
+    }
+    fn receiving_shares_account(&self) -> Pubkey {
+        self.receiving_shares_account
+    }
+    fn depositing_underlying_account(&self) -> Pubkey {
+        self.depositing_underlying_account
+    }
+    fn vault_underlying_account(&self) -> Pubkey {
+        self.vault_underlying_account
+    }
+    fn instruction(&self, farm_type: Farm, amount: u64) -> Option<Instruction> {
+        let ix_sighash = self.ix_data()?;
+        // 8 bytes for the sighash, 8 bytes for the amount
+        // 16 bytes for the serialized farm_type
+        let mut ix_data = Vec::with_capacity(32);
+        ix_data.extend_from_slice(&ix_sighash[..]);
+        match farm_type.serialize() {
+            Ok(farm_type_data) => ix_data.extend_from_slice(&farm_type_data[..]),
+            Err(_err) => {
+                #[cfg(feature = "logs")]
+                msg!("failed to serialize farm_type {:#?}", err);
+                return None;
+            }
+        }
+        match AnchorSerialize::try_to_vec(&amount) {
+            Ok(amount_data) => ix_data.extend_from_slice(&amount_data[..]),
+            Err(_err) => {
+                #[cfg(feature = "logs")]
+                msg!("failed to serialize amount {:#?}", err);
+                return None;
+            }
+        }
+        Some(Instruction {
+            program_id: crate::config::ID,
+            accounts: self.to_account_meta(None),
+            data: ix_data,
+        })
+    }
+    fn ix_data(&self) -> Option<[u8; 8]> {
+        GlobalSighashDB.get("permissioned_issue_shares")
+    }
+    fn to_account_meta(&self, _is_signer: Option<bool>) -> Vec<AccountMeta> {
+        vec![
+            AccountMeta::new_readonly(self.authority(), true),
+            AccountMeta::new(self.vault(), false),
+            AccountMeta::new_readonly(super::super::V2_MANAGEMENT, false),
             AccountMeta::new_readonly(self.vault_pda(), false),
             AccountMeta::new(self.vault_underlying_account(), false),
             AccountMeta::new(self.shares_mint(), false),

--- a/common/src/config/mod.rs
+++ b/common/src/config/mod.rs
@@ -16,6 +16,9 @@ use static_pubkey::static_pubkey;
 
 /// tulip v2 vaults program id
 pub const ID: Pubkey = static_pubkey!("TLPv2tuSVvn3fSk8RgW3yPddkp5oFivzZV3rA9hQxtX");
+/// address of the v2 management account
+pub const V2_MANAGEMENT: Pubkey = static_pubkey!("9bqD5JcQoMD88PJ11o7quULTh5rHFF5u6C6xi2461ADD");
+
 pub const SUNNY_QUARRY_PROGRAM: Pubkey =
     static_pubkey!("SPQR4kT3q2oUKEJes2L6NNSBCiPW9SfuhkuqC9bp6Sx");
 pub const ORCA_AQUAFARM_PROGRAM: Pubkey =

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1079,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "sighashdb"
-version = "0.1.34"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b58e91b6af83a51250c848b1c676767effd62b6270fa23e1d3341c814ef76f9"
+checksum = "393be469778e092958422c81b8bdacca35b1033caeacbcc72b70a599962cd985"
 
 [[package]]
 name = "smallvec"
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "tulipv2-sdk-common"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "tulipv2-sdk-farms"
-version = "0.9.19"
+version = "0.9.21"
 dependencies = [
  "anchor-lang",
  "tulip-arrform",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "tulipv2-sdk-lending"
-version = "0.9.19"
+version = "0.9.21"
 dependencies = [
  "itertools",
  "num-derive",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "tulipv2-sdk-levfarm"
-version = "0.9.17"
+version = "0.9.21"
 dependencies = [
  "anchor-lang",
  "itertools",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "tulipv2-sdk-vaults"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/leveraged/Cargo.toml
+++ b/leveraged/Cargo.toml
@@ -109,7 +109,7 @@ thiserror = "1.0"
 num-traits = "0.2"
 anchor-lang = "0.24.2"
 static-pubkey = "1.0.2"
-sighashdb = "0.1.32"
+sighashdb = "0.1.37"
 [dev-dependencies]
 proptest = "1.0.0"
 solana-client = "1.9.13"

--- a/vaults/Cargo.toml
+++ b/vaults/Cargo.toml
@@ -27,7 +27,7 @@ tulip-arrform = "0.1.1"
 tulip-derivative = "2.2.1"
 itertools = "0.10.3"
 tulipv2-sdk-farms = {path = "../farms", version = "0.9.21"}
-sighashdb = "0.1.34"
+sighashdb = "0.1.37"
 so-defi-atrix = "0.1.16"
 bytemuck = "1.7.2"
 [dev-dependencies]

--- a/vaults/src/config/atrix.rs
+++ b/vaults/src/config/atrix.rs
@@ -5,7 +5,7 @@ use crate::accounts::{
 use anchor_lang::solana_program::pubkey::Pubkey;
 use so_defi_atrix::addresses as atrix_addresses;
 
-use tulipv2_sdk_common::config::deposit_tracking::issue_shares::DepositAddresses;
+use tulipv2_sdk_common::config::deposit_tracking::issue_shares::{DepositAddresses, DepositAddressesPermissioned};
 use tulipv2_sdk_common::config::deposit_tracking::register::RegisterDepositTrackingAddresses;
 use tulipv2_sdk_common::config::deposit_tracking::traits::{
     IssueShares, RegisterDepositTracking, WithdrawDepositTracking,
@@ -75,6 +75,15 @@ impl AtrixVaultConfig {
             self.pda,
             self.shares_mint,
             self.underlying_mint,
+        )
+    }
+    pub fn permissioned_issue_shares(&self, authority: Pubkey) -> impl IssueShares {
+        DepositAddressesPermissioned::new(
+            authority,
+            self.vault,
+            self.pda,
+            self.shares_mint,
+            self.underlying_mint
         )
     }
     pub fn withdraw_deposit_tracking(&self, authority: Pubkey) -> impl WithdrawDepositTracking {

--- a/vaults/src/config/orca.rs
+++ b/vaults/src/config/orca.rs
@@ -8,7 +8,7 @@ use crate::accounts::{
 };
 use anchor_lang::solana_program::instruction::Instruction;
 use anchor_lang::solana_program::pubkey::Pubkey;
-use tulipv2_sdk_common::config::deposit_tracking::issue_shares::DepositAddresses;
+use tulipv2_sdk_common::config::deposit_tracking::issue_shares::{DepositAddresses, DepositAddressesPermissioned};
 use tulipv2_sdk_common::config::deposit_tracking::register::RegisterDepositTrackingAddresses;
 use tulipv2_sdk_common::config::deposit_tracking::traits::{
     IssueShares, RegisterDepositTracking, WithdrawDepositTracking,
@@ -103,6 +103,15 @@ impl OrcaVaultConfig {
             self.pda,
             self.shares_mint,
             self.underlying_mint,
+        )
+    }
+    pub fn permissioned_issue_shares(&self, authority: Pubkey) -> impl IssueShares {
+        DepositAddressesPermissioned::new(
+            authority,
+            self.vault,
+            self.pda,
+            self.shares_mint,
+            self.underlying_mint
         )
     }
     pub fn withdraw_deposit_tracking(&self, authority: Pubkey) -> impl WithdrawDepositTracking {

--- a/vaults/src/config/quarry.rs
+++ b/vaults/src/config/quarry.rs
@@ -92,6 +92,7 @@ impl QuarrySunnyVaultConfig {
             sunny_tvault_internal_token_account,
         }
     }
+    
 }
 
 impl QuarrySaberVaultConfig {

--- a/vaults/src/config/raydium.rs
+++ b/vaults/src/config/raydium.rs
@@ -6,7 +6,7 @@ use crate::accounts::{
 
 use anchor_lang::solana_program::instruction::Instruction;
 use anchor_lang::solana_program::pubkey::Pubkey;
-use tulipv2_sdk_common::config::deposit_tracking::issue_shares::DepositAddresses;
+use tulipv2_sdk_common::config::deposit_tracking::issue_shares::{DepositAddresses, DepositAddressesPermissioned};
 use tulipv2_sdk_common::config::deposit_tracking::register::RegisterDepositTrackingAddresses;
 use tulipv2_sdk_common::config::deposit_tracking::traits::{
     IssueShares, RegisterDepositTracking, WithdrawDepositTracking,
@@ -87,6 +87,15 @@ impl RaydiumVaultConfig {
             self.pda,
             self.shares_mint,
             self.underlying_mint,
+        )
+    }
+    pub fn permissioned_issue_shares(&self, authority: Pubkey) -> impl IssueShares {
+        DepositAddressesPermissioned::new(
+            authority,
+            self.vault,
+            self.pda,
+            self.shares_mint,
+            self.underlying_mint
         )
     }
     pub fn withdraw_deposit_tracking(&self, authority: Pubkey) -> impl WithdrawDepositTracking {

--- a/vaults/src/instructions/mod.rs
+++ b/vaults/src/instructions/mod.rs
@@ -53,3 +53,37 @@ pub fn new_issue_shares_ix(
         data: ix_data,
     })
 }
+
+pub fn new_permissioned_issue_shares_ix(
+    authority: Pubkey,
+    vault: Pubkey,
+    vault_pda: Pubkey,
+    vault_underlying_account: Pubkey,
+    shares_mint: Pubkey,
+    receiving_shares_account: Pubkey,
+    depositing_underlying_account: Pubkey,
+    farm_type: Farm,
+    amount: u64,
+) -> Option<Instruction> {
+    let ix_sighash = GlobalSighashDB.get("permissioned_issue_shares")?;
+    let farm_type: [u64; 2] = farm_type.into();
+    let mut ix_data = Vec::with_capacity(40);
+    ix_data.extend_from_slice(&ix_sighash[..]);
+    ix_data.extend_from_slice(&AnchorSerialize::try_to_vec(&farm_type).ok()?[..]);
+    ix_data.extend_from_slice(&AnchorSerialize::try_to_vec(&amount).unwrap());
+    Some(Instruction {
+        program_id: crate::ID,
+        accounts: vec![
+            AccountMeta::new_readonly(authority, true),
+            AccountMeta::new(vault, false),
+            AccountMeta::new_readonly(crate::MANAGEMENT, false),
+            AccountMeta::new_readonly(vault_pda, false),
+            AccountMeta::new(vault_underlying_account, false),
+            AccountMeta::new(shares_mint, false),
+            AccountMeta::new(receiving_shares_account, false),
+            AccountMeta::new(depositing_underlying_account, false),
+            AccountMeta::new(spl_token::id(), false),
+        ],
+        data: ix_data,
+    })   
+}

--- a/vaults/src/lib.rs
+++ b/vaults/src/lib.rs
@@ -6,3 +6,4 @@ use anchor_lang::solana_program::{self, pubkey::Pubkey};
 use static_pubkey::static_pubkey;
 
 pub const ID: Pubkey = static_pubkey!("TLPv2tuSVvn3fSk8RgW3yPddkp5oFivzZV3rA9hQxtX");
+pub const MANAGEMENT: Pubkey = tulipv2_sdk_common::config::V2_MANAGEMENT;


### PR DESCRIPTION
adds example + instruction for invoking the `permissioned_issue_shares` instruction