### PR TITLE
[WIP] Add Traits For Strategy Vault Configuration

### DIFF
--- a/common/src/config/strategy/mod.rs
+++ b/common/src/config/strategy/mod.rs
@@ -1,5 +1,7 @@
 //! tulip strategy vault configurations
 
+use self::traits::MultiVaultProgramConfig;
+
 pub mod traits;
 pub mod withdraw;
 
@@ -20,4 +22,121 @@ pub enum Platform {
     MangoV3,
     Tulip,
     Solend,
+}
+
+
+#[derive(Clone, Copy)]
+pub enum StrategyVaults {
+    USDCv1,
+    SOLv1,
+    RAYv1,
+    USDTv1,
+}
+
+impl StrategyVaults {
+    pub fn multi_deposit_config(&self) -> Box<dyn MultiVaultProgramConfig> {
+        match self {
+            Self::USDCv1 => Box::new(usdc::multi_deposit::ProgramConfig) as Box<dyn MultiVaultProgramConfig>,
+            Self::SOLv1 => Box::new(sol::multi_deposit::ProgramConfig) as Box<dyn MultiVaultProgramConfig>,
+            Self::RAYv1 => Box::new(ray::multi_deposit::ProgramConfig) as Box<dyn MultiVaultProgramConfig>,
+            Self::USDTv1 => Box::new(usdt::multi_deposit::ProgramConfig) as Box<dyn MultiVaultProgramConfig>,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_sol_multi_deposit_config() {
+        let conf = StrategyVaults::SOLv1.multi_deposit_config();   
+
+        assert_eq!(conf.account(), sol::multi_deposit::ACCOUNT);
+        assert_eq!(conf.pda(), sol::multi_deposit::PDA);
+        assert_eq!(conf.shares_mint(), sol::multi_deposit::SHARES_MINT);
+        assert_eq!(conf.underlying_compound_queue(), sol::multi_deposit::UNDERLYING_COMPOUND_QUEUE);
+        assert_eq!(conf.underlying_deposit_queue(), sol::multi_deposit::UNDERLYING_DEPOSIT_QUEUE);
+        assert_eq!(conf.underlying_withdraw_queue(), sol::multi_deposit::UNDERLYING_WITHDRAW_QUEUE);
+        assert_eq!(conf.underlying_mint(), sol::multi_deposit::UNDERLYING_MINT);
+        assert_eq!(conf.rebalance_state_transition(), sol::multi_deposit::REBALANCE_STATE_TRANSITION);
+        assert_eq!(conf.rebalance_state_transition_underlying(), sol::multi_deposit::REBALANCE_STATE_TRANSITION_UNDERLYING);
+        assert_eq!(conf.optimizer_shares_account(Platform::MangoV3), sol::multi_deposit::MANGO_OPTIMIZER_SHARES_ACCOUNT);
+        assert_eq!(conf.optimizer_shares_account(Platform::Tulip), sol::multi_deposit::TULIP_OPTIMIZER_SHARES_ACCOUNT);
+        assert_eq!(conf.optimizer_shares_account(Platform::Solend), sol::multi_deposit::SOLEND_OPTIMIZER_SHARES_ACCOUNT);
+
+        // TODO: validate the issue_shares, etc... methods
+
+        assert_eq!(conf.remaining_accounts(Platform::MangoV3), sol::multi_deposit::ProgramConfig::get_mango_remaining_accounts());
+        assert_eq!(conf.remaining_accounts(Platform::Tulip), sol::multi_deposit::ProgramConfig::get_tulip_remaining_accounts());
+        assert_eq!(conf.remaining_accounts(Platform::Solend), sol::multi_deposit::ProgramConfig::get_solend_remaining_accounts());
+    }
+    #[test]
+    fn test_ray_multi_deposit_config() {
+        let conf = StrategyVaults::RAYv1.multi_deposit_config();   
+
+        assert_eq!(conf.account(), ray::multi_deposit::ACCOUNT);
+        assert_eq!(conf.pda(), ray::multi_deposit::PDA);
+        assert_eq!(conf.shares_mint(), ray::multi_deposit::SHARES_MINT);
+        assert_eq!(conf.underlying_compound_queue(), ray::multi_deposit::UNDERLYING_COMPOUND_QUEUE);
+        assert_eq!(conf.underlying_deposit_queue(), ray::multi_deposit::UNDERLYING_DEPOSIT_QUEUE);
+        assert_eq!(conf.underlying_withdraw_queue(), ray::multi_deposit::UNDERLYING_WITHDRAW_QUEUE);
+        assert_eq!(conf.underlying_mint(), ray::multi_deposit::UNDERLYING_MINT);
+        assert_eq!(conf.rebalance_state_transition(), ray::multi_deposit::REBALANCE_STATE_TRANSITION);
+        assert_eq!(conf.rebalance_state_transition_underlying(), ray::multi_deposit::REBALANCE_STATE_TRANSITION_UNDERLYING);
+        assert_eq!(conf.optimizer_shares_account(Platform::MangoV3), ray::multi_deposit::MANGO_OPTIMIZER_SHARES_ACCOUNT);
+        assert_eq!(conf.optimizer_shares_account(Platform::Tulip), ray::multi_deposit::TULIP_OPTIMIZER_SHARES_ACCOUNT);
+        assert_eq!(conf.optimizer_shares_account(Platform::Solend), ray::multi_deposit::SOLEND_OPTIMIZER_SHARES_ACCOUNT);
+
+        // TODO: validate the issue_shares, etc... methods
+
+        assert_eq!(conf.remaining_accounts(Platform::MangoV3), ray::multi_deposit::ProgramConfig::get_mango_remaining_accounts());
+        assert_eq!(conf.remaining_accounts(Platform::Tulip), ray::multi_deposit::ProgramConfig::get_tulip_remaining_accounts());
+        assert_eq!(conf.remaining_accounts(Platform::Solend), ray::multi_deposit::ProgramConfig::get_solend_remaining_accounts());
+    }
+    #[test]
+    fn test_usdc_multi_deposit_config() {
+        let conf = StrategyVaults::USDCv1.multi_deposit_config();   
+
+        assert_eq!(conf.account(), usdc::multi_deposit::ACCOUNT);
+        assert_eq!(conf.pda(), usdc::multi_deposit::PDA);
+        assert_eq!(conf.shares_mint(), usdc::multi_deposit::SHARES_MINT);
+        assert_eq!(conf.underlying_compound_queue(), usdc::multi_deposit::UNDERLYING_COMPOUND_QUEUE);
+        assert_eq!(conf.underlying_deposit_queue(), usdc::multi_deposit::UNDERLYING_DEPOSIT_QUEUE);
+        assert_eq!(conf.underlying_withdraw_queue(), usdc::multi_deposit::UNDERLYING_WITHDRAW_QUEUE);
+        assert_eq!(conf.underlying_mint(), usdc::multi_deposit::UNDERLYING_MINT);
+        assert_eq!(conf.rebalance_state_transition(), usdc::multi_deposit::REBALANCE_STATE_TRANSITION);
+        assert_eq!(conf.rebalance_state_transition_underlying(), usdc::multi_deposit::REBALANCE_STATE_TRANSITION_UNDERLYING);
+        assert_eq!(conf.optimizer_shares_account(Platform::MangoV3), usdc::multi_deposit::MANGO_OPTIMIZER_SHARES_ACCOUNT);
+        assert_eq!(conf.optimizer_shares_account(Platform::Tulip), usdc::multi_deposit::TULIP_OPTIMIZER_SHARES_ACCOUNT);
+        assert_eq!(conf.optimizer_shares_account(Platform::Solend), usdc::multi_deposit::SOLEND_OPTIMIZER_SHARES_ACCOUNT);
+
+        // TODO: validate the issue_shares, etc... methods
+
+        assert_eq!(conf.remaining_accounts(Platform::MangoV3), usdc::multi_deposit::ProgramConfig::get_mango_remaining_accounts());
+        assert_eq!(conf.remaining_accounts(Platform::Tulip), usdc::multi_deposit::ProgramConfig::get_tulip_remaining_accounts());
+        assert_eq!(conf.remaining_accounts(Platform::Solend), usdc::multi_deposit::ProgramConfig::get_solend_remaining_accounts());
+    }
+    #[test]
+    fn test_usdt_multi_deposit_config() {
+        let conf = StrategyVaults::USDTv1.multi_deposit_config();   
+
+        assert_eq!(conf.account(), usdt::multi_deposit::ACCOUNT);
+        assert_eq!(conf.pda(), usdt::multi_deposit::PDA);
+        assert_eq!(conf.shares_mint(), usdt::multi_deposit::SHARES_MINT);
+        assert_eq!(conf.underlying_compound_queue(), usdt::multi_deposit::UNDERLYING_COMPOUND_QUEUE);
+        assert_eq!(conf.underlying_deposit_queue(), usdt::multi_deposit::UNDERLYING_DEPOSIT_QUEUE);
+        assert_eq!(conf.underlying_withdraw_queue(), usdt::multi_deposit::UNDERLYING_WITHDRAW_QUEUE);
+        assert_eq!(conf.underlying_mint(), usdt::multi_deposit::UNDERLYING_MINT);
+        assert_eq!(conf.rebalance_state_transition(), usdt::multi_deposit::REBALANCE_STATE_TRANSITION);
+        assert_eq!(conf.rebalance_state_transition_underlying(), usdt::multi_deposit::REBALANCE_STATE_TRANSITION_UNDERLYING);
+        assert_eq!(conf.optimizer_shares_account(Platform::MangoV3), usdt::multi_deposit::MANGO_OPTIMIZER_SHARES_ACCOUNT);
+        assert_eq!(conf.optimizer_shares_account(Platform::Tulip), usdt::multi_deposit::TULIP_OPTIMIZER_SHARES_ACCOUNT);
+        assert_eq!(conf.optimizer_shares_account(Platform::Solend), usdt::multi_deposit::SOLEND_OPTIMIZER_SHARES_ACCOUNT);
+
+        // TODO: validate the issue_shares, etc... methods
+
+        assert_eq!(conf.remaining_accounts(Platform::MangoV3), usdt::multi_deposit::ProgramConfig::get_mango_remaining_accounts());
+        assert_eq!(conf.remaining_accounts(Platform::Tulip), usdt::multi_deposit::ProgramConfig::get_tulip_remaining_accounts());
+        assert_eq!(conf.remaining_accounts(Platform::Solend), usdt::multi_deposit::ProgramConfig::get_solend_remaining_accounts());
+    }
 }

--- a/common/src/config/strategy/mod.rs
+++ b/common/src/config/strategy/mod.rs
@@ -1,6 +1,6 @@
 //! tulip strategy vault configurations
 
-use self::traits::MultiVaultProgramConfig;
+use self::traits::{MultiVaultProgramConfig, StandaloneVaultProgramConfig};
 
 pub mod traits;
 pub mod withdraw;
@@ -24,7 +24,6 @@ pub enum Platform {
     Solend,
 }
 
-
 #[derive(Clone, Copy)]
 pub enum StrategyVaults {
     USDCv1,
@@ -34,109 +33,726 @@ pub enum StrategyVaults {
 }
 
 impl StrategyVaults {
+    /// returns the multi deposit vault program configuration trait for strategy vault `self`
     pub fn multi_deposit_config(&self) -> Box<dyn MultiVaultProgramConfig> {
         match self {
-            Self::USDCv1 => Box::new(usdc::multi_deposit::ProgramConfig) as Box<dyn MultiVaultProgramConfig>,
-            Self::SOLv1 => Box::new(sol::multi_deposit::ProgramConfig) as Box<dyn MultiVaultProgramConfig>,
-            Self::RAYv1 => Box::new(ray::multi_deposit::ProgramConfig) as Box<dyn MultiVaultProgramConfig>,
-            Self::USDTv1 => Box::new(usdt::multi_deposit::ProgramConfig) as Box<dyn MultiVaultProgramConfig>,
+            Self::USDCv1 => {
+                Box::new(usdc::multi_deposit::ProgramConfig) as Box<dyn MultiVaultProgramConfig>
+            }
+            Self::SOLv1 => {
+                Box::new(sol::multi_deposit::ProgramConfig) as Box<dyn MultiVaultProgramConfig>
+            }
+            Self::RAYv1 => {
+                Box::new(ray::multi_deposit::ProgramConfig) as Box<dyn MultiVaultProgramConfig>
+            }
+            Self::USDTv1 => {
+                Box::new(usdt::multi_deposit::ProgramConfig) as Box<dyn MultiVaultProgramConfig>
+            }
+        }
+    }
+    /// returns the standalone vault program configuration for the standalone vault belonging to `platform`
+    /// used by the strategy vault as indicated by `self`
+    pub fn standalone_config(&self, platform: Platform) -> Box<dyn StandaloneVaultProgramConfig> {
+        match self {
+            Self::USDCv1 => self.multi_deposit_config().standalone_config(platform),
+            Self::SOLv1 => self.multi_deposit_config().standalone_config(platform),
+            Self::RAYv1 => self.multi_deposit_config().standalone_config(platform),
+            Self::USDTv1 => self.multi_deposit_config().standalone_config(platform),
         }
     }
 }
 
 #[cfg(test)]
 mod test {
+    use tulipv2_sdk_farms::{lending::Lending, Farm};
+
     use super::*;
     #[test]
     fn test_sol_multi_deposit_config() {
-        let conf = StrategyVaults::SOLv1.multi_deposit_config();   
+        let conf = StrategyVaults::SOLv1.multi_deposit_config();
 
         assert_eq!(conf.account(), sol::multi_deposit::ACCOUNT);
         assert_eq!(conf.pda(), sol::multi_deposit::PDA);
         assert_eq!(conf.shares_mint(), sol::multi_deposit::SHARES_MINT);
-        assert_eq!(conf.underlying_compound_queue(), sol::multi_deposit::UNDERLYING_COMPOUND_QUEUE);
-        assert_eq!(conf.underlying_deposit_queue(), sol::multi_deposit::UNDERLYING_DEPOSIT_QUEUE);
-        assert_eq!(conf.underlying_withdraw_queue(), sol::multi_deposit::UNDERLYING_WITHDRAW_QUEUE);
+        assert_eq!(
+            conf.underlying_compound_queue(),
+            sol::multi_deposit::UNDERLYING_COMPOUND_QUEUE
+        );
+        assert_eq!(
+            conf.underlying_deposit_queue(),
+            sol::multi_deposit::UNDERLYING_DEPOSIT_QUEUE
+        );
+        assert_eq!(
+            conf.underlying_withdraw_queue(),
+            sol::multi_deposit::UNDERLYING_WITHDRAW_QUEUE
+        );
         assert_eq!(conf.underlying_mint(), sol::multi_deposit::UNDERLYING_MINT);
-        assert_eq!(conf.rebalance_state_transition(), sol::multi_deposit::REBALANCE_STATE_TRANSITION);
-        assert_eq!(conf.rebalance_state_transition_underlying(), sol::multi_deposit::REBALANCE_STATE_TRANSITION_UNDERLYING);
-        assert_eq!(conf.optimizer_shares_account(Platform::MangoV3), sol::multi_deposit::MANGO_OPTIMIZER_SHARES_ACCOUNT);
-        assert_eq!(conf.optimizer_shares_account(Platform::Tulip), sol::multi_deposit::TULIP_OPTIMIZER_SHARES_ACCOUNT);
-        assert_eq!(conf.optimizer_shares_account(Platform::Solend), sol::multi_deposit::SOLEND_OPTIMIZER_SHARES_ACCOUNT);
+        assert_eq!(
+            conf.rebalance_state_transition(),
+            sol::multi_deposit::REBALANCE_STATE_TRANSITION
+        );
+        assert_eq!(
+            conf.rebalance_state_transition_underlying(),
+            sol::multi_deposit::REBALANCE_STATE_TRANSITION_UNDERLYING
+        );
+        assert_eq!(
+            conf.optimizer_shares_account(Platform::MangoV3),
+            sol::multi_deposit::MANGO_OPTIMIZER_SHARES_ACCOUNT
+        );
+        assert_eq!(
+            conf.optimizer_shares_account(Platform::Tulip),
+            sol::multi_deposit::TULIP_OPTIMIZER_SHARES_ACCOUNT
+        );
+        assert_eq!(
+            conf.optimizer_shares_account(Platform::Solend),
+            sol::multi_deposit::SOLEND_OPTIMIZER_SHARES_ACCOUNT
+        );
 
         // TODO: validate the issue_shares, etc... methods
 
-        assert_eq!(conf.remaining_accounts(Platform::MangoV3), sol::multi_deposit::ProgramConfig::get_mango_remaining_accounts());
-        assert_eq!(conf.remaining_accounts(Platform::Tulip), sol::multi_deposit::ProgramConfig::get_tulip_remaining_accounts());
-        assert_eq!(conf.remaining_accounts(Platform::Solend), sol::multi_deposit::ProgramConfig::get_solend_remaining_accounts());
+        assert_eq!(
+            conf.remaining_accounts(Platform::MangoV3),
+            sol::multi_deposit::ProgramConfig::get_mango_remaining_accounts()
+        );
+        assert_eq!(
+            conf.remaining_accounts(Platform::Tulip),
+            sol::multi_deposit::ProgramConfig::get_tulip_remaining_accounts()
+        );
+        assert_eq!(
+            conf.remaining_accounts(Platform::Solend),
+            sol::multi_deposit::ProgramConfig::get_solend_remaining_accounts()
+        );
+
+        assert_eq!(conf.tag(), "solv1");
+        assert_eq!(
+            conf.farm(),
+            Farm::Lending {
+                name: Lending::MULTI_DEPOSIT
+            }
+        );
+
+        let standalone_config = StrategyVaults::SOLv1.standalone_config(Platform::MangoV3);
+        assert_eq!(standalone_config.account(), sol::mango::ACCOUNT);
+        assert_eq!(standalone_config.pda(), sol::mango::PDA);
+        assert_eq!(standalone_config.shares_mint(), sol::mango::SHARES_MINT);
+        assert_eq!(
+            standalone_config.underlying_compound_queue(),
+            sol::mango::UNDERLYING_COMPOUND_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_deposit_queue(),
+            sol::mango::UNDERLYING_DEPOSIT_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_mint(),
+            sol::mango::UNDERLYING_MINT
+        );
+        assert_eq!(
+            standalone_config.config_data_account(),
+            sol::mango::CONFIG_DATA_ACCOUNT
+        );
+        assert_eq!(
+            standalone_config.information_account(),
+            sol::mango::INFORMATION_ACCOUNT
+        );
+        assert_eq!(standalone_config.program_id(), sol::mango::PROGRAM_ID);
+        assert!(standalone_config.mango_config().is_some());
+        assert!(standalone_config.tulip_config().is_none());
+        assert!(standalone_config.solend_config().is_none());
+        assert!(standalone_config.is_platform(Platform::MangoV3));
+        assert_eq!(standalone_config.tag(), "mango");
+        assert_eq!(
+            standalone_config.farm(),
+            Farm::Lending { name: Lending::SOL }
+        );
+
+        let standalone_config = StrategyVaults::SOLv1.standalone_config(Platform::Solend);
+        assert_eq!(standalone_config.account(), sol::solend::ACCOUNT);
+        assert_eq!(standalone_config.pda(), sol::solend::PDA);
+        assert_eq!(standalone_config.shares_mint(), sol::solend::SHARES_MINT);
+        assert_eq!(
+            standalone_config.underlying_compound_queue(),
+            sol::solend::UNDERLYING_COMPOUND_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_deposit_queue(),
+            sol::solend::UNDERLYING_DEPOSIT_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_mint(),
+            sol::solend::UNDERLYING_MINT
+        );
+        assert_eq!(
+            standalone_config.config_data_account(),
+            sol::solend::CONFIG_DATA_ACCOUNT
+        );
+        assert_eq!(
+            standalone_config.information_account(),
+            sol::solend::INFORMATION_ACCOUNT
+        );
+        assert_eq!(standalone_config.program_id(), sol::solend::PROGRAM_ID);
+        assert!(standalone_config.mango_config().is_none());
+        assert!(standalone_config.tulip_config().is_none());
+        assert!(standalone_config.solend_config().is_some());
+        assert!(standalone_config.is_platform(Platform::Solend));
+        assert_eq!(standalone_config.tag(), "solend");
+        assert_eq!(
+            standalone_config.farm(),
+            Farm::Lending { name: Lending::SOL }
+        );
+
+        let standalone_config = StrategyVaults::SOLv1.standalone_config(Platform::Tulip);
+        assert_eq!(standalone_config.account(), sol::tulip::ACCOUNT);
+        assert_eq!(standalone_config.pda(), sol::tulip::PDA);
+        assert_eq!(standalone_config.shares_mint(), sol::tulip::SHARES_MINT);
+        assert_eq!(
+            standalone_config.underlying_compound_queue(),
+            sol::tulip::UNDERLYING_COMPOUND_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_deposit_queue(),
+            sol::tulip::UNDERLYING_DEPOSIT_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_mint(),
+            sol::tulip::UNDERLYING_MINT
+        );
+        assert_eq!(
+            standalone_config.config_data_account(),
+            sol::tulip::CONFIG_DATA_ACCOUNT
+        );
+        assert_eq!(
+            standalone_config.information_account(),
+            sol::tulip::INFORMATION_ACCOUNT
+        );
+        assert_eq!(standalone_config.program_id(), sol::tulip::PROGRAM_ID);
+        assert!(standalone_config.mango_config().is_none());
+        assert!(standalone_config.tulip_config().is_some());
+        assert!(standalone_config.solend_config().is_none());
+        assert!(standalone_config.is_platform(Platform::Tulip));
+        assert_eq!(standalone_config.tag(), "tulip");
+        assert_eq!(
+            standalone_config.farm(),
+            Farm::Lending { name: Lending::SOL }
+        );
     }
     #[test]
     fn test_ray_multi_deposit_config() {
-        let conf = StrategyVaults::RAYv1.multi_deposit_config();   
+        let conf = StrategyVaults::RAYv1.multi_deposit_config();
 
         assert_eq!(conf.account(), ray::multi_deposit::ACCOUNT);
         assert_eq!(conf.pda(), ray::multi_deposit::PDA);
         assert_eq!(conf.shares_mint(), ray::multi_deposit::SHARES_MINT);
-        assert_eq!(conf.underlying_compound_queue(), ray::multi_deposit::UNDERLYING_COMPOUND_QUEUE);
-        assert_eq!(conf.underlying_deposit_queue(), ray::multi_deposit::UNDERLYING_DEPOSIT_QUEUE);
-        assert_eq!(conf.underlying_withdraw_queue(), ray::multi_deposit::UNDERLYING_WITHDRAW_QUEUE);
+        assert_eq!(
+            conf.underlying_compound_queue(),
+            ray::multi_deposit::UNDERLYING_COMPOUND_QUEUE
+        );
+        assert_eq!(
+            conf.underlying_deposit_queue(),
+            ray::multi_deposit::UNDERLYING_DEPOSIT_QUEUE
+        );
+        assert_eq!(
+            conf.underlying_withdraw_queue(),
+            ray::multi_deposit::UNDERLYING_WITHDRAW_QUEUE
+        );
         assert_eq!(conf.underlying_mint(), ray::multi_deposit::UNDERLYING_MINT);
-        assert_eq!(conf.rebalance_state_transition(), ray::multi_deposit::REBALANCE_STATE_TRANSITION);
-        assert_eq!(conf.rebalance_state_transition_underlying(), ray::multi_deposit::REBALANCE_STATE_TRANSITION_UNDERLYING);
-        assert_eq!(conf.optimizer_shares_account(Platform::MangoV3), ray::multi_deposit::MANGO_OPTIMIZER_SHARES_ACCOUNT);
-        assert_eq!(conf.optimizer_shares_account(Platform::Tulip), ray::multi_deposit::TULIP_OPTIMIZER_SHARES_ACCOUNT);
-        assert_eq!(conf.optimizer_shares_account(Platform::Solend), ray::multi_deposit::SOLEND_OPTIMIZER_SHARES_ACCOUNT);
+        assert_eq!(
+            conf.rebalance_state_transition(),
+            ray::multi_deposit::REBALANCE_STATE_TRANSITION
+        );
+        assert_eq!(
+            conf.rebalance_state_transition_underlying(),
+            ray::multi_deposit::REBALANCE_STATE_TRANSITION_UNDERLYING
+        );
+        assert_eq!(
+            conf.optimizer_shares_account(Platform::MangoV3),
+            ray::multi_deposit::MANGO_OPTIMIZER_SHARES_ACCOUNT
+        );
+        assert_eq!(
+            conf.optimizer_shares_account(Platform::Tulip),
+            ray::multi_deposit::TULIP_OPTIMIZER_SHARES_ACCOUNT
+        );
+        assert_eq!(
+            conf.optimizer_shares_account(Platform::Solend),
+            ray::multi_deposit::SOLEND_OPTIMIZER_SHARES_ACCOUNT
+        );
 
         // TODO: validate the issue_shares, etc... methods
 
-        assert_eq!(conf.remaining_accounts(Platform::MangoV3), ray::multi_deposit::ProgramConfig::get_mango_remaining_accounts());
-        assert_eq!(conf.remaining_accounts(Platform::Tulip), ray::multi_deposit::ProgramConfig::get_tulip_remaining_accounts());
-        assert_eq!(conf.remaining_accounts(Platform::Solend), ray::multi_deposit::ProgramConfig::get_solend_remaining_accounts());
+        assert_eq!(
+            conf.remaining_accounts(Platform::MangoV3),
+            ray::multi_deposit::ProgramConfig::get_mango_remaining_accounts()
+        );
+        assert_eq!(
+            conf.remaining_accounts(Platform::Tulip),
+            ray::multi_deposit::ProgramConfig::get_tulip_remaining_accounts()
+        );
+        assert_eq!(
+            conf.remaining_accounts(Platform::Solend),
+            ray::multi_deposit::ProgramConfig::get_solend_remaining_accounts()
+        );
+
+        assert_eq!(conf.tag(), "rayv1");
+        assert_eq!(
+            conf.farm(),
+            Farm::Lending {
+                name: Lending::MULTI_DEPOSIT
+            }
+        );
+
+        let standalone_config = StrategyVaults::RAYv1.standalone_config(Platform::MangoV3);
+        assert_eq!(standalone_config.account(), ray::mango::ACCOUNT);
+        assert_eq!(standalone_config.pda(), ray::mango::PDA);
+        assert_eq!(standalone_config.shares_mint(), ray::mango::SHARES_MINT);
+        assert_eq!(
+            standalone_config.underlying_compound_queue(),
+            ray::mango::UNDERLYING_COMPOUND_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_deposit_queue(),
+            ray::mango::UNDERLYING_DEPOSIT_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_mint(),
+            ray::mango::UNDERLYING_MINT
+        );
+        assert_eq!(
+            standalone_config.config_data_account(),
+            ray::mango::CONFIG_DATA_ACCOUNT
+        );
+        assert_eq!(
+            standalone_config.information_account(),
+            ray::mango::INFORMATION_ACCOUNT
+        );
+        assert_eq!(standalone_config.program_id(), ray::mango::PROGRAM_ID);
+        assert!(standalone_config.mango_config().is_some());
+        assert!(standalone_config.tulip_config().is_none());
+        assert!(standalone_config.solend_config().is_none());
+        assert!(standalone_config.is_platform(Platform::MangoV3));
+        assert_eq!(standalone_config.tag(), "mango");
+        assert_eq!(
+            standalone_config.farm(),
+            Farm::Lending { name: Lending::RAY }
+        );
+
+        let standalone_config = StrategyVaults::RAYv1.standalone_config(Platform::Solend);
+        assert_eq!(standalone_config.account(), ray::solend::ACCOUNT);
+        assert_eq!(standalone_config.pda(), ray::solend::PDA);
+        assert_eq!(standalone_config.shares_mint(), ray::solend::SHARES_MINT);
+        assert_eq!(
+            standalone_config.underlying_compound_queue(),
+            ray::solend::UNDERLYING_COMPOUND_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_deposit_queue(),
+            ray::solend::UNDERLYING_DEPOSIT_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_mint(),
+            ray::solend::UNDERLYING_MINT
+        );
+        assert_eq!(
+            standalone_config.config_data_account(),
+            ray::solend::CONFIG_DATA_ACCOUNT
+        );
+        assert_eq!(
+            standalone_config.information_account(),
+            ray::solend::INFORMATION_ACCOUNT
+        );
+        assert_eq!(standalone_config.program_id(), ray::solend::PROGRAM_ID);
+        assert!(standalone_config.mango_config().is_none());
+        assert!(standalone_config.tulip_config().is_none());
+        assert!(standalone_config.solend_config().is_some());
+        assert!(standalone_config.is_platform(Platform::Solend));
+        assert_eq!(standalone_config.tag(), "solend");
+        assert_eq!(
+            standalone_config.farm(),
+            Farm::Lending { name: Lending::RAY }
+        );
+
+        let standalone_config = StrategyVaults::RAYv1.standalone_config(Platform::Tulip);
+        assert_eq!(standalone_config.account(), ray::tulip::ACCOUNT);
+        assert_eq!(standalone_config.pda(), ray::tulip::PDA);
+        assert_eq!(standalone_config.shares_mint(), ray::tulip::SHARES_MINT);
+        assert_eq!(
+            standalone_config.underlying_compound_queue(),
+            ray::tulip::UNDERLYING_COMPOUND_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_deposit_queue(),
+            ray::tulip::UNDERLYING_DEPOSIT_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_mint(),
+            ray::tulip::UNDERLYING_MINT
+        );
+        assert_eq!(
+            standalone_config.config_data_account(),
+            ray::tulip::CONFIG_DATA_ACCOUNT
+        );
+        assert_eq!(
+            standalone_config.information_account(),
+            ray::tulip::INFORMATION_ACCOUNT
+        );
+        assert_eq!(standalone_config.program_id(), ray::tulip::PROGRAM_ID);
+        assert!(standalone_config.mango_config().is_none());
+        assert!(standalone_config.tulip_config().is_some());
+        assert!(standalone_config.solend_config().is_none());
+        assert!(standalone_config.is_platform(Platform::Tulip));
+        assert_eq!(standalone_config.tag(), "tulip");
+        assert_eq!(
+            standalone_config.farm(),
+            Farm::Lending { name: Lending::RAY }
+        );
     }
     #[test]
     fn test_usdc_multi_deposit_config() {
-        let conf = StrategyVaults::USDCv1.multi_deposit_config();   
+        let conf = StrategyVaults::USDCv1.multi_deposit_config();
 
         assert_eq!(conf.account(), usdc::multi_deposit::ACCOUNT);
         assert_eq!(conf.pda(), usdc::multi_deposit::PDA);
         assert_eq!(conf.shares_mint(), usdc::multi_deposit::SHARES_MINT);
-        assert_eq!(conf.underlying_compound_queue(), usdc::multi_deposit::UNDERLYING_COMPOUND_QUEUE);
-        assert_eq!(conf.underlying_deposit_queue(), usdc::multi_deposit::UNDERLYING_DEPOSIT_QUEUE);
-        assert_eq!(conf.underlying_withdraw_queue(), usdc::multi_deposit::UNDERLYING_WITHDRAW_QUEUE);
+        assert_eq!(
+            conf.underlying_compound_queue(),
+            usdc::multi_deposit::UNDERLYING_COMPOUND_QUEUE
+        );
+        assert_eq!(
+            conf.underlying_deposit_queue(),
+            usdc::multi_deposit::UNDERLYING_DEPOSIT_QUEUE
+        );
+        assert_eq!(
+            conf.underlying_withdraw_queue(),
+            usdc::multi_deposit::UNDERLYING_WITHDRAW_QUEUE
+        );
         assert_eq!(conf.underlying_mint(), usdc::multi_deposit::UNDERLYING_MINT);
-        assert_eq!(conf.rebalance_state_transition(), usdc::multi_deposit::REBALANCE_STATE_TRANSITION);
-        assert_eq!(conf.rebalance_state_transition_underlying(), usdc::multi_deposit::REBALANCE_STATE_TRANSITION_UNDERLYING);
-        assert_eq!(conf.optimizer_shares_account(Platform::MangoV3), usdc::multi_deposit::MANGO_OPTIMIZER_SHARES_ACCOUNT);
-        assert_eq!(conf.optimizer_shares_account(Platform::Tulip), usdc::multi_deposit::TULIP_OPTIMIZER_SHARES_ACCOUNT);
-        assert_eq!(conf.optimizer_shares_account(Platform::Solend), usdc::multi_deposit::SOLEND_OPTIMIZER_SHARES_ACCOUNT);
+        assert_eq!(
+            conf.rebalance_state_transition(),
+            usdc::multi_deposit::REBALANCE_STATE_TRANSITION
+        );
+        assert_eq!(
+            conf.rebalance_state_transition_underlying(),
+            usdc::multi_deposit::REBALANCE_STATE_TRANSITION_UNDERLYING
+        );
+        assert_eq!(
+            conf.optimizer_shares_account(Platform::MangoV3),
+            usdc::multi_deposit::MANGO_OPTIMIZER_SHARES_ACCOUNT
+        );
+        assert_eq!(
+            conf.optimizer_shares_account(Platform::Tulip),
+            usdc::multi_deposit::TULIP_OPTIMIZER_SHARES_ACCOUNT
+        );
+        assert_eq!(
+            conf.optimizer_shares_account(Platform::Solend),
+            usdc::multi_deposit::SOLEND_OPTIMIZER_SHARES_ACCOUNT
+        );
 
         // TODO: validate the issue_shares, etc... methods
 
-        assert_eq!(conf.remaining_accounts(Platform::MangoV3), usdc::multi_deposit::ProgramConfig::get_mango_remaining_accounts());
-        assert_eq!(conf.remaining_accounts(Platform::Tulip), usdc::multi_deposit::ProgramConfig::get_tulip_remaining_accounts());
-        assert_eq!(conf.remaining_accounts(Platform::Solend), usdc::multi_deposit::ProgramConfig::get_solend_remaining_accounts());
+        assert_eq!(
+            conf.remaining_accounts(Platform::MangoV3),
+            usdc::multi_deposit::ProgramConfig::get_mango_remaining_accounts()
+        );
+        assert_eq!(
+            conf.remaining_accounts(Platform::Tulip),
+            usdc::multi_deposit::ProgramConfig::get_tulip_remaining_accounts()
+        );
+        assert_eq!(
+            conf.remaining_accounts(Platform::Solend),
+            usdc::multi_deposit::ProgramConfig::get_solend_remaining_accounts()
+        );
+
+        assert_eq!(conf.tag(), "usdcv1");
+        assert_eq!(
+            conf.farm(),
+            Farm::Lending {
+                name: Lending::MULTI_DEPOSIT
+            }
+        );
+
+        let standalone_config = StrategyVaults::USDCv1.standalone_config(Platform::MangoV3);
+        assert_eq!(standalone_config.account(), usdc::mango::ACCOUNT);
+        assert_eq!(standalone_config.pda(), usdc::mango::PDA);
+        assert_eq!(standalone_config.shares_mint(), usdc::mango::SHARES_MINT);
+        assert_eq!(
+            standalone_config.underlying_compound_queue(),
+            usdc::mango::UNDERLYING_COMPOUND_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_deposit_queue(),
+            usdc::mango::UNDERLYING_DEPOSIT_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_mint(),
+            usdc::mango::UNDERLYING_MINT
+        );
+        assert_eq!(
+            standalone_config.config_data_account(),
+            usdc::mango::CONFIG_DATA_ACCOUNT
+        );
+        assert_eq!(
+            standalone_config.information_account(),
+            usdc::mango::INFORMATION_ACCOUNT
+        );
+        assert_eq!(standalone_config.program_id(), usdc::mango::PROGRAM_ID);
+        assert!(standalone_config.mango_config().is_some());
+        assert!(standalone_config.tulip_config().is_none());
+        assert!(standalone_config.solend_config().is_none());
+        assert!(standalone_config.is_platform(Platform::MangoV3));
+        assert_eq!(standalone_config.tag(), "mango");
+        assert_eq!(
+            standalone_config.farm(),
+            Farm::Lending {
+                name: Lending::USDC
+            }
+        );
+
+        let standalone_config = StrategyVaults::USDCv1.standalone_config(Platform::Solend);
+        assert_eq!(standalone_config.account(), usdc::solend::ACCOUNT);
+        assert_eq!(standalone_config.pda(), usdc::solend::PDA);
+        assert_eq!(standalone_config.shares_mint(), usdc::solend::SHARES_MINT);
+        assert_eq!(
+            standalone_config.underlying_compound_queue(),
+            usdc::solend::UNDERLYING_COMPOUND_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_deposit_queue(),
+            usdc::solend::UNDERLYING_DEPOSIT_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_mint(),
+            usdc::solend::UNDERLYING_MINT
+        );
+        assert_eq!(
+            standalone_config.config_data_account(),
+            usdc::solend::CONFIG_DATA_ACCOUNT
+        );
+        assert_eq!(
+            standalone_config.information_account(),
+            usdc::solend::INFORMATION_ACCOUNT
+        );
+        assert_eq!(standalone_config.program_id(), usdc::solend::PROGRAM_ID);
+        assert!(standalone_config.mango_config().is_none());
+        assert!(standalone_config.tulip_config().is_none());
+        assert!(standalone_config.solend_config().is_some());
+        assert!(standalone_config.is_platform(Platform::Solend));
+        assert_eq!(standalone_config.tag(), "solend");
+        assert_eq!(
+            standalone_config.farm(),
+            Farm::Lending {
+                name: Lending::USDC
+            }
+        );
+
+        let standalone_config = StrategyVaults::USDCv1.standalone_config(Platform::Tulip);
+        assert_eq!(standalone_config.account(), usdc::tulip::ACCOUNT);
+        assert_eq!(standalone_config.pda(), usdc::tulip::PDA);
+        assert_eq!(standalone_config.shares_mint(), usdc::tulip::SHARES_MINT);
+        assert_eq!(
+            standalone_config.underlying_compound_queue(),
+            usdc::tulip::UNDERLYING_COMPOUND_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_deposit_queue(),
+            usdc::tulip::UNDERLYING_DEPOSIT_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_mint(),
+            usdc::tulip::UNDERLYING_MINT
+        );
+        assert_eq!(
+            standalone_config.config_data_account(),
+            usdc::tulip::CONFIG_DATA_ACCOUNT
+        );
+        assert_eq!(
+            standalone_config.information_account(),
+            usdc::tulip::INFORMATION_ACCOUNT
+        );
+        assert_eq!(standalone_config.program_id(), usdc::tulip::PROGRAM_ID);
+        assert!(standalone_config.mango_config().is_none());
+        assert!(standalone_config.tulip_config().is_some());
+        assert!(standalone_config.solend_config().is_none());
+        assert!(standalone_config.is_platform(Platform::Tulip));
+        assert_eq!(standalone_config.tag(), "tulip");
+        assert_eq!(
+            standalone_config.farm(),
+            Farm::Lending {
+                name: Lending::USDC
+            }
+        );
     }
     #[test]
     fn test_usdt_multi_deposit_config() {
-        let conf = StrategyVaults::USDTv1.multi_deposit_config();   
+        let conf = StrategyVaults::USDTv1.multi_deposit_config();
 
         assert_eq!(conf.account(), usdt::multi_deposit::ACCOUNT);
         assert_eq!(conf.pda(), usdt::multi_deposit::PDA);
         assert_eq!(conf.shares_mint(), usdt::multi_deposit::SHARES_MINT);
-        assert_eq!(conf.underlying_compound_queue(), usdt::multi_deposit::UNDERLYING_COMPOUND_QUEUE);
-        assert_eq!(conf.underlying_deposit_queue(), usdt::multi_deposit::UNDERLYING_DEPOSIT_QUEUE);
-        assert_eq!(conf.underlying_withdraw_queue(), usdt::multi_deposit::UNDERLYING_WITHDRAW_QUEUE);
+        assert_eq!(
+            conf.underlying_compound_queue(),
+            usdt::multi_deposit::UNDERLYING_COMPOUND_QUEUE
+        );
+        assert_eq!(
+            conf.underlying_deposit_queue(),
+            usdt::multi_deposit::UNDERLYING_DEPOSIT_QUEUE
+        );
+        assert_eq!(
+            conf.underlying_withdraw_queue(),
+            usdt::multi_deposit::UNDERLYING_WITHDRAW_QUEUE
+        );
         assert_eq!(conf.underlying_mint(), usdt::multi_deposit::UNDERLYING_MINT);
-        assert_eq!(conf.rebalance_state_transition(), usdt::multi_deposit::REBALANCE_STATE_TRANSITION);
-        assert_eq!(conf.rebalance_state_transition_underlying(), usdt::multi_deposit::REBALANCE_STATE_TRANSITION_UNDERLYING);
-        assert_eq!(conf.optimizer_shares_account(Platform::MangoV3), usdt::multi_deposit::MANGO_OPTIMIZER_SHARES_ACCOUNT);
-        assert_eq!(conf.optimizer_shares_account(Platform::Tulip), usdt::multi_deposit::TULIP_OPTIMIZER_SHARES_ACCOUNT);
-        assert_eq!(conf.optimizer_shares_account(Platform::Solend), usdt::multi_deposit::SOLEND_OPTIMIZER_SHARES_ACCOUNT);
+        assert_eq!(
+            conf.rebalance_state_transition(),
+            usdt::multi_deposit::REBALANCE_STATE_TRANSITION
+        );
+        assert_eq!(
+            conf.rebalance_state_transition_underlying(),
+            usdt::multi_deposit::REBALANCE_STATE_TRANSITION_UNDERLYING
+        );
+        assert_eq!(
+            conf.optimizer_shares_account(Platform::MangoV3),
+            usdt::multi_deposit::MANGO_OPTIMIZER_SHARES_ACCOUNT
+        );
+        assert_eq!(
+            conf.optimizer_shares_account(Platform::Tulip),
+            usdt::multi_deposit::TULIP_OPTIMIZER_SHARES_ACCOUNT
+        );
+        assert_eq!(
+            conf.optimizer_shares_account(Platform::Solend),
+            usdt::multi_deposit::SOLEND_OPTIMIZER_SHARES_ACCOUNT
+        );
 
         // TODO: validate the issue_shares, etc... methods
 
-        assert_eq!(conf.remaining_accounts(Platform::MangoV3), usdt::multi_deposit::ProgramConfig::get_mango_remaining_accounts());
-        assert_eq!(conf.remaining_accounts(Platform::Tulip), usdt::multi_deposit::ProgramConfig::get_tulip_remaining_accounts());
-        assert_eq!(conf.remaining_accounts(Platform::Solend), usdt::multi_deposit::ProgramConfig::get_solend_remaining_accounts());
+        assert_eq!(
+            conf.remaining_accounts(Platform::MangoV3),
+            usdt::multi_deposit::ProgramConfig::get_mango_remaining_accounts()
+        );
+        assert_eq!(
+            conf.remaining_accounts(Platform::Tulip),
+            usdt::multi_deposit::ProgramConfig::get_tulip_remaining_accounts()
+        );
+        assert_eq!(
+            conf.remaining_accounts(Platform::Solend),
+            usdt::multi_deposit::ProgramConfig::get_solend_remaining_accounts()
+        );
+
+        assert_eq!(conf.tag(), "usdtv1");
+        assert_eq!(
+            conf.farm(),
+            Farm::Lending {
+                name: Lending::MULTI_DEPOSIT
+            }
+        );
+
+        let standalone_config = StrategyVaults::USDTv1.standalone_config(Platform::MangoV3);
+        assert_eq!(standalone_config.account(), usdt::mango::ACCOUNT);
+        assert_eq!(standalone_config.pda(), usdt::mango::PDA);
+        assert_eq!(standalone_config.shares_mint(), usdt::mango::SHARES_MINT);
+        assert_eq!(
+            standalone_config.underlying_compound_queue(),
+            usdt::mango::UNDERLYING_COMPOUND_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_deposit_queue(),
+            usdt::mango::UNDERLYING_DEPOSIT_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_mint(),
+            usdt::mango::UNDERLYING_MINT
+        );
+        assert_eq!(
+            standalone_config.config_data_account(),
+            usdt::mango::CONFIG_DATA_ACCOUNT
+        );
+        assert_eq!(
+            standalone_config.information_account(),
+            usdt::mango::INFORMATION_ACCOUNT
+        );
+        assert_eq!(standalone_config.program_id(), usdt::mango::PROGRAM_ID);
+        assert!(standalone_config.mango_config().is_some());
+        assert!(standalone_config.tulip_config().is_none());
+        assert!(standalone_config.solend_config().is_none());
+        assert!(standalone_config.is_platform(Platform::MangoV3));
+        assert_eq!(standalone_config.tag(), "mango");
+        assert_eq!(
+            standalone_config.farm(),
+            Farm::Lending {
+                name: Lending::USDT
+            }
+        );
+
+        let standalone_config = StrategyVaults::USDTv1.standalone_config(Platform::Solend);
+        assert_eq!(standalone_config.account(), usdt::solend::ACCOUNT);
+        assert_eq!(standalone_config.pda(), usdt::solend::PDA);
+        assert_eq!(standalone_config.shares_mint(), usdt::solend::SHARES_MINT);
+        assert_eq!(
+            standalone_config.underlying_compound_queue(),
+            usdt::solend::UNDERLYING_COMPOUND_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_deposit_queue(),
+            usdt::solend::UNDERLYING_DEPOSIT_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_mint(),
+            usdt::solend::UNDERLYING_MINT
+        );
+        assert_eq!(
+            standalone_config.config_data_account(),
+            usdt::solend::CONFIG_DATA_ACCOUNT
+        );
+        assert_eq!(
+            standalone_config.information_account(),
+            usdt::solend::INFORMATION_ACCOUNT
+        );
+        assert_eq!(standalone_config.program_id(), usdt::solend::PROGRAM_ID);
+        assert!(standalone_config.mango_config().is_none());
+        assert!(standalone_config.tulip_config().is_none());
+        assert!(standalone_config.solend_config().is_some());
+        assert!(standalone_config.is_platform(Platform::Solend));
+        assert_eq!(standalone_config.tag(), "solend");
+        assert_eq!(
+            standalone_config.farm(),
+            Farm::Lending {
+                name: Lending::USDT
+            }
+        );
+
+        let standalone_config = StrategyVaults::USDTv1.standalone_config(Platform::Tulip);
+        assert_eq!(standalone_config.account(), usdt::tulip::ACCOUNT);
+        assert_eq!(standalone_config.pda(), usdt::tulip::PDA);
+        assert_eq!(standalone_config.shares_mint(), usdt::tulip::SHARES_MINT);
+        assert_eq!(
+            standalone_config.underlying_compound_queue(),
+            usdt::tulip::UNDERLYING_COMPOUND_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_deposit_queue(),
+            usdt::tulip::UNDERLYING_DEPOSIT_QUEUE
+        );
+        assert_eq!(
+            standalone_config.underlying_mint(),
+            usdt::tulip::UNDERLYING_MINT
+        );
+        assert_eq!(
+            standalone_config.config_data_account(),
+            usdt::tulip::CONFIG_DATA_ACCOUNT
+        );
+        assert_eq!(
+            standalone_config.information_account(),
+            usdt::tulip::INFORMATION_ACCOUNT
+        );
+        assert_eq!(standalone_config.program_id(), usdt::tulip::PROGRAM_ID);
+        assert!(standalone_config.mango_config().is_none());
+        assert!(standalone_config.tulip_config().is_some());
+        assert!(standalone_config.solend_config().is_none());
+        assert!(standalone_config.is_platform(Platform::Tulip));
+        assert_eq!(standalone_config.tag(), "tulip");
+        assert_eq!(
+            standalone_config.farm(),
+            Farm::Lending {
+                name: Lending::USDT
+            }
+        );
     }
 }

--- a/common/src/config/strategy/mod.rs
+++ b/common/src/config/strategy/mod.rs
@@ -24,7 +24,7 @@ pub enum Platform {
     Solend,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum StrategyVaults {
     USDCv1,
     SOLv1,

--- a/common/src/config/strategy/mod.rs
+++ b/common/src/config/strategy/mod.rs
@@ -62,6 +62,19 @@ impl StrategyVaults {
     }
 }
 
+/// given address `vault`, return the corresponding multi deposit vault configuration trait.
+/// 
+/// returns None if the vault is not a strategy vault
+pub fn get_multi_deposit_vault_config(vault: anchor_lang::solana_program::pubkey::Pubkey) -> Option<Box<dyn MultiVaultProgramConfig>> {
+    match vault {
+        usdc::multi_deposit::ACCOUNT => Some(StrategyVaults::USDCv1.multi_deposit_config()),
+        sol::multi_deposit::ACCOUNT => Some(StrategyVaults::SOLv1.multi_deposit_config()),
+        ray::multi_deposit::ACCOUNT => Some(StrategyVaults::RAYv1.multi_deposit_config()),
+        usdt::multi_deposit::ACCOUNT => Some(StrategyVaults::USDTv1.multi_deposit_config()),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod test {
     use tulipv2_sdk_farms::{lending::Lending, Farm};
@@ -69,7 +82,8 @@ mod test {
     use super::*;
     #[test]
     fn test_sol_multi_deposit_config() {
-        let conf = StrategyVaults::SOLv1.multi_deposit_config();
+        let conf = get_multi_deposit_vault_config(sol::multi_deposit::ACCOUNT).unwrap();
+
 
         assert_eq!(conf.account(), sol::multi_deposit::ACCOUNT);
         assert_eq!(conf.pda(), sol::multi_deposit::PDA);
@@ -238,7 +252,7 @@ mod test {
     }
     #[test]
     fn test_ray_multi_deposit_config() {
-        let conf = StrategyVaults::RAYv1.multi_deposit_config();
+        let conf = get_multi_deposit_vault_config(ray::multi_deposit::ACCOUNT).unwrap();
 
         assert_eq!(conf.account(), ray::multi_deposit::ACCOUNT);
         assert_eq!(conf.pda(), ray::multi_deposit::PDA);
@@ -407,7 +421,7 @@ mod test {
     }
     #[test]
     fn test_usdc_multi_deposit_config() {
-        let conf = StrategyVaults::USDCv1.multi_deposit_config();
+        let conf = get_multi_deposit_vault_config(usdc::multi_deposit::ACCOUNT).unwrap();
 
         assert_eq!(conf.account(), usdc::multi_deposit::ACCOUNT);
         assert_eq!(conf.pda(), usdc::multi_deposit::PDA);
@@ -582,7 +596,7 @@ mod test {
     }
     #[test]
     fn test_usdt_multi_deposit_config() {
-        let conf = StrategyVaults::USDTv1.multi_deposit_config();
+        let conf = get_multi_deposit_vault_config(usdt::multi_deposit::ACCOUNT).unwrap();
 
         assert_eq!(conf.account(), usdt::multi_deposit::ACCOUNT);
         assert_eq!(conf.pda(), usdt::multi_deposit::PDA);

--- a/common/src/config/strategy/mod.rs
+++ b/common/src/config/strategy/mod.rs
@@ -1,9 +1,5 @@
 //! tulip strategy vault configurations
 
-use anchor_lang::prelude::AccountLoader;
-use solana_program::account_info::AccountInfo;
-use tulipv2_sdk_farms::{lending::Lending, Farm};
-
 use self::traits::{MultiVaultProgramConfig, StandaloneVaultProgramConfig};
 
 pub mod traits;

--- a/common/src/config/strategy/mod.rs
+++ b/common/src/config/strategy/mod.rs
@@ -1,5 +1,9 @@
 //! tulip strategy vault configurations
 
+use anchor_lang::prelude::AccountLoader;
+use solana_program::account_info::AccountInfo;
+use tulipv2_sdk_farms::{lending::Lending, Farm};
+
 use self::traits::{MultiVaultProgramConfig, StandaloneVaultProgramConfig};
 
 pub mod traits;

--- a/common/src/config/strategy/ray.rs
+++ b/common/src/config/strategy/ray.rs
@@ -1,6 +1,7 @@
 //! usdc lending optimizer configuration variables
 
 use crate::config::deposit_tracking::issue_shares::DepositAddresses;
+use crate::config::deposit_tracking::issue_shares::DepositAddressesPermissioned;
 use crate::config::deposit_tracking::register::RegisterDepositTrackingAddresses;
 use crate::config::deposit_tracking::traits::{
     IssueShares, RegisterDepositTracking, WithdrawDepositTracking,
@@ -13,17 +14,17 @@ use anchor_lang::prelude::*;
 use anchor_lang::solana_program;
 use static_pubkey::static_pubkey;
 use tulipv2_sdk_farms::{lending::Lending, Farm};
-use crate::config::deposit_tracking::issue_shares::DepositAddressesPermissioned;
 
 /// bundles configuration information for the usdc lending optimizer multi deposit vault
 
 pub mod multi_deposit {
-    use crate::config::strategy::traits::MultiVaultProgramConfig;
+    use crate::config::strategy::traits::{MultiVaultProgramConfig, StandaloneVaultProgramConfig};
 
     use super::*;
 
     /// empty struct used to implement the various traits used
     /// to interact with the ray lending optimizer vault
+    #[derive(Clone, Copy)]
     pub struct ProgramConfig;
 
     pub const TAG_STRING: &str = "rayv1";
@@ -161,38 +162,38 @@ pub mod multi_deposit {
         }
     }
     impl MultiVaultProgramConfig for ProgramConfig {
-        fn account(&self, ) -> Pubkey {
+        fn account(&self) -> Pubkey {
             ACCOUNT
         }
-        fn pda(&self, ) -> Pubkey {
+        fn pda(&self) -> Pubkey {
             PDA
         }
-        fn shares_mint(&self, ) -> Pubkey {
+        fn shares_mint(&self) -> Pubkey {
             SHARES_MINT
         }
-        fn underlying_compound_queue(&self, ) -> Pubkey {
+        fn underlying_compound_queue(&self) -> Pubkey {
             UNDERLYING_COMPOUND_QUEUE
         }
-        fn underlying_deposit_queue(&self, ) -> Pubkey {
+        fn underlying_deposit_queue(&self) -> Pubkey {
             UNDERLYING_DEPOSIT_QUEUE
         }
-        fn underlying_withdraw_queue(&self, ) -> Pubkey {
+        fn underlying_withdraw_queue(&self) -> Pubkey {
             UNDERLYING_WITHDRAW_QUEUE
         }
-        fn underlying_mint(&self, ) -> Pubkey {
+        fn underlying_mint(&self) -> Pubkey {
             UNDERLYING_MINT
         }
-        fn rebalance_state_transition(&self, ) -> Pubkey {
+        fn rebalance_state_transition(&self) -> Pubkey {
             REBALANCE_STATE_TRANSITION
         }
-        fn rebalance_state_transition_underlying(&self, ) -> Pubkey {
+        fn rebalance_state_transition_underlying(&self) -> Pubkey {
             REBALANCE_STATE_TRANSITION_UNDERLYING
         }
         fn optimizer_shares_account(&self, platform: Platform) -> Pubkey {
             match platform {
                 Platform::MangoV3 => MANGO_OPTIMIZER_SHARES_ACCOUNT,
                 Platform::Solend => SOLEND_OPTIMIZER_SHARES_ACCOUNT,
-                Platform::Tulip => TULIP_OPTIMIZER_SHARES_ACCOUNT
+                Platform::Tulip => TULIP_OPTIMIZER_SHARES_ACCOUNT,
             }
         }
         fn issue_shares(&self, user: Pubkey) -> Box<dyn IssueShares> {
@@ -205,10 +206,16 @@ pub mod multi_deposit {
             Box::new(ProgramConfig::register_deposit_tracking_ix(user))
         }
         fn withdraw_deposit_tracking(&self, user: Pubkey) -> Box<dyn WithdrawDepositTracking> {
-            Box::new( ProgramConfig::withdraw_deposit_tracking_ix(user))
+            Box::new(ProgramConfig::withdraw_deposit_tracking_ix(user))
         }
-        fn withdraw_multi_deposit_optimizer_vault(&self, user: Pubkey, platform: Platform) -> std::result::Result<Box<dyn WithdrawMultiOptimizerVault>, std::io::Error> {
-            Ok(ProgramConfig::withdraw_multi_deposit_optimizer_vault(user, platform)?)
+        fn withdraw_multi_deposit_optimizer_vault(
+            &self,
+            user: Pubkey,
+            platform: Platform,
+        ) -> std::result::Result<Box<dyn WithdrawMultiOptimizerVault>, std::io::Error> {
+            Ok(ProgramConfig::withdraw_multi_deposit_optimizer_vault(
+                user, platform,
+            )?)
         }
         fn remaining_accounts(&self, platform: Platform) -> Vec<Pubkey> {
             match platform {
@@ -217,14 +224,38 @@ pub mod multi_deposit {
                 Platform::Tulip => ProgramConfig::get_tulip_remaining_accounts().to_vec(),
             }
         }
+        fn standalone_config(&self, platform: Platform) -> Box<dyn StandaloneVaultProgramConfig> {
+            match platform {
+                Platform::MangoV3 => Box::new(mango::ProgramConfig),
+                Platform::Solend => Box::new(solend::ProgramConfig),
+                Platform::Tulip => Box::new(tulip::ProgramConfig),
+            }
+        }
+        fn farm(&self) -> Farm {
+            FARM_KEY
+        }
+        fn tag(&self) -> &str {
+            TAG_STRING
+        }
     }
 }
 
 /// bundles configuration information for the solend usdc standalone vault
 pub mod solend {
-    use super::*;
+    use crate::config::strategy::{
+        traits::{SolendProgramConfig, StandaloneVaultProgramConfig},
+        withdraw::PlatformConfigAddresses,
+        Platform,
+    };
+
+    use anchor_lang::solana_program::{self, pubkey::Pubkey};
+    use static_pubkey::static_pubkey;
+    use tulipv2_sdk_farms::{lending::Lending, Farm};
     pub const TAG_STRING: &str = "solend";
     pub const FARM_KEY: Farm = Farm::Lending { name: Lending::RAY };
+
+    #[derive(Clone, Copy)]
+    pub struct ProgramConfig;
 
     /// address of the standalone vault itself
     pub const ACCOUNT: Pubkey = static_pubkey!("8eAWyCa27MCukBBswRWBMc6RB4pLQQ2oyXr7sTKFvGXH");
@@ -298,14 +329,114 @@ pub mod solend {
             lending_program: PROGRAM_ID,
         }
     }
+
+    impl StandaloneVaultProgramConfig for ProgramConfig {
+        fn account(&self) -> Pubkey {
+            ACCOUNT
+        }
+        fn pda(&self) -> Pubkey {
+            PDA
+        }
+        fn shares_mint(&self) -> Pubkey {
+            SHARES_MINT
+        }
+        fn underlying_compound_queue(&self) -> Pubkey {
+            UNDERLYING_COMPOUND_QUEUE
+        }
+        fn underlying_deposit_queue(&self) -> Pubkey {
+            UNDERLYING_DEPOSIT_QUEUE
+        }
+        fn underlying_withdraw_queue(&self) -> Pubkey {
+            UNDERLYING_WITHDRAW_QUEUE
+        }
+        fn underlying_mint(&self) -> Pubkey {
+            UNDERLYING_MINT
+        }
+        fn config_data_account(&self) -> Pubkey {
+            CONFIG_DATA_ACCOUNT
+        }
+        fn information_account(&self) -> Pubkey {
+            INFORMATION_ACCOUNT
+        }
+        fn program_id(&self) -> Pubkey {
+            PROGRAM_ID
+        }
+        fn solend_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::SolendProgramConfig>> {
+            Some(Box::new(*self))
+        }
+        fn tulip_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::TulipProgramConfig>> {
+            None
+        }
+        fn mango_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::MangoProgramConfig>> {
+            None
+        }
+        fn is_platform(&self, platform: Platform) -> bool {
+            matches!(platform, Platform::Solend)
+        }
+        fn farm(&self) -> Farm {
+            FARM_KEY
+        }
+        fn tag(&self) -> &str {
+            TAG_STRING
+        }
+    }
+    impl SolendProgramConfig for ProgramConfig {
+        fn collateral_mint(&self) -> Pubkey {
+            COLLATERAL_MINT
+        }
+        fn lending_market(&self) -> Pubkey {
+            LENDING_MARKET_ACCOUNT
+        }
+        fn lending_market_authority(&self) -> Pubkey {
+            LENDING_MARKET_AUTHORITY
+        }
+        fn pyth_price_account(&self) -> Pubkey {
+            PYTH_PRICE_ACCOUNT
+        }
+        fn switchboard_price_account(&self) -> Pubkey {
+            SWITCHBOARD_PRICE_ACCOUNT
+        }
+        fn pyth_program_id(&self) -> Pubkey {
+            PYTH_PROGRAM_ID
+        }
+        fn switchboard_program_id(&self) -> Pubkey {
+            SWITCHBOARD_PROGRAM_ID
+        }
+        fn reserve(&self) -> Pubkey {
+            RESERVE_ACCOUNT
+        }
+        fn reserve_liquidity(&self) -> Pubkey {
+            RESERVE_LIQUIDITY_ACCOUNT
+        }
+        fn vault_collateral_account(&self) -> Pubkey {
+            COLLATERAL_TOKEN_ACCOUNT
+        }
+    }
 }
 
 /// bundles configuration information for the tulip usdc standalone vault
 pub mod tulip {
-    use super::*;
+    use crate::config::strategy::{
+        traits::{StandaloneVaultProgramConfig, TulipProgramConfig},
+        withdraw::PlatformConfigAddresses,
+        Platform,
+    };
+
+    use anchor_lang::solana_program::{self, pubkey::Pubkey};
+    use static_pubkey::static_pubkey;
+    use tulipv2_sdk_farms::{lending::Lending, Farm};
 
     pub const TAG_STRING: &str = "tulip";
     pub const FARM_KEY: Farm = Farm::Lending { name: Lending::RAY };
+
+    #[derive(Clone, Copy)]
+    pub struct ProgramConfig;
 
     /// address of the standalone vault itself
     pub const ACCOUNT: Pubkey = static_pubkey!("7RqGWFDK8J7AUB498ged2ZrmK5otqPE2nFM5RZQ3sCZ3");
@@ -372,14 +503,108 @@ pub mod tulip {
             lending_program: PROGRAM_ID,
         }
     }
+
+    impl StandaloneVaultProgramConfig for ProgramConfig {
+        fn account(&self) -> Pubkey {
+            ACCOUNT
+        }
+        fn pda(&self) -> Pubkey {
+            PDA
+        }
+        fn shares_mint(&self) -> Pubkey {
+            SHARES_MINT
+        }
+        fn underlying_compound_queue(&self) -> Pubkey {
+            UNDERLYING_COMPOUND_QUEUE
+        }
+        fn underlying_deposit_queue(&self) -> Pubkey {
+            UNDERLYING_DEPOSIT_QUEUE
+        }
+        fn underlying_withdraw_queue(&self) -> Pubkey {
+            UNDERLYING_WITHDRAW_QUEUE
+        }
+        fn underlying_mint(&self) -> Pubkey {
+            UNDERLYING_MINT
+        }
+        fn config_data_account(&self) -> Pubkey {
+            CONFIG_DATA_ACCOUNT
+        }
+        fn information_account(&self) -> Pubkey {
+            INFORMATION_ACCOUNT
+        }
+        fn program_id(&self) -> Pubkey {
+            PROGRAM_ID
+        }
+        fn solend_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::SolendProgramConfig>> {
+            None
+        }
+        fn tulip_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::TulipProgramConfig>> {
+            Some(Box::new(*self))
+        }
+        fn mango_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::MangoProgramConfig>> {
+            None
+        }
+        fn is_platform(&self, platform: Platform) -> bool {
+            matches!(platform, Platform::Tulip)
+        }
+        fn farm(&self) -> Farm {
+            FARM_KEY
+        }
+        fn tag(&self) -> &str {
+            TAG_STRING
+        }
+    }
+    impl TulipProgramConfig for ProgramConfig {
+        fn collateral_mint(&self) -> Pubkey {
+            COLLATERAL_MINT
+        }
+        fn lending_market(&self) -> Pubkey {
+            LENDING_MARKET_ACCOUNT
+        }
+        fn lending_market_authority(&self) -> Pubkey {
+            LENDING_MARKET_AUTHORITY
+        }
+        fn pyth_price_account(&self) -> Pubkey {
+            PYTH_PRICE_ACCOUNT
+        }
+        fn pyth_program_id(&self) -> Pubkey {
+            PYTH_PROGRAM_ID
+        }
+        fn reserve(&self) -> Pubkey {
+            RESERVE_ACCOUNT
+        }
+        fn reserve_liquidity(&self) -> Pubkey {
+            RESERVE_LIQUIDITY_ACCOUNT
+        }
+        fn vault_collateral_account(&self) -> Pubkey {
+            COLLATERAL_TOKEN_ACCOUNT
+        }
+    }
 }
 
 /// bundles configuration information for the mango usdc standalone vault
 pub mod mango {
-    use super::*;
+    use crate::config::strategy::{
+        traits::{MangoProgramConfig, StandaloneVaultProgramConfig},
+        withdraw::PlatformConfigAddresses,
+        Platform,
+    };
+
+    use anchor_lang::solana_program::{self, pubkey::Pubkey};
+    use static_pubkey::static_pubkey;
+    use tulipv2_sdk_farms::{lending::Lending, Farm};
 
     pub const TAG_STRING: &str = "mango";
     pub const FARM_KEY: Farm = Farm::Lending { name: Lending::RAY };
+
+    #[derive(Clone, Copy)]
+    pub struct ProgramConfig;
 
     /// address of the standalone vault itself
     pub const ACCOUNT: Pubkey = static_pubkey!("A1tu6mY4CrVynaNTVPMtWfecJmXT2nNqwkhmyAjRaSvc");
@@ -432,6 +657,86 @@ pub mod mango {
             shares_mint: SHARES_MINT,
             underlying_deposit_queue: UNDERLYING_DEPOSIT_QUEUE,
             lending_program: PROGRAM_ID,
+        }
+    }
+
+    impl StandaloneVaultProgramConfig for ProgramConfig {
+        fn account(&self) -> Pubkey {
+            ACCOUNT
+        }
+        fn pda(&self) -> Pubkey {
+            PDA
+        }
+        fn shares_mint(&self) -> Pubkey {
+            SHARES_MINT
+        }
+        fn underlying_compound_queue(&self) -> Pubkey {
+            UNDERLYING_COMPOUND_QUEUE
+        }
+        fn underlying_deposit_queue(&self) -> Pubkey {
+            UNDERLYING_DEPOSIT_QUEUE
+        }
+        fn underlying_withdraw_queue(&self) -> Pubkey {
+            UNDERLYING_WITHDRAW_QUEUE
+        }
+        fn underlying_mint(&self) -> Pubkey {
+            UNDERLYING_MINT
+        }
+        fn config_data_account(&self) -> Pubkey {
+            CONFIG_DATA_ACCOUNT
+        }
+        fn information_account(&self) -> Pubkey {
+            INFORMATION_ACCOUNT
+        }
+        fn program_id(&self) -> Pubkey {
+            PROGRAM_ID
+        }
+        fn solend_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::SolendProgramConfig>> {
+            None
+        }
+        fn tulip_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::TulipProgramConfig>> {
+            None
+        }
+        fn mango_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::MangoProgramConfig>> {
+            Some(Box::new(*self))
+        }
+        fn is_platform(&self, platform: Platform) -> bool {
+            matches!(platform, Platform::MangoV3)
+        }
+        fn farm(&self) -> Farm {
+            FARM_KEY
+        }
+        fn tag(&self) -> &str {
+            TAG_STRING
+        }
+    }
+    impl MangoProgramConfig for ProgramConfig {
+        fn cache(&self) -> Pubkey {
+            CACHE
+        }
+        fn group(&self) -> Pubkey {
+            GROUP
+        }
+        fn group_signer(&self) -> Pubkey {
+            GROUP_SIGNER
+        }
+        fn group_token_account(&self) -> Pubkey {
+            GROUP_TOKEN_ACCOUNT
+        }
+        fn root_bank(&self) -> Pubkey {
+            ROOT_BANK
+        }
+        fn node_bank(&self) -> Pubkey {
+            NODE_BANK
+        }
+        fn optimizer_mango_account(&self) -> Pubkey {
+            OPTIMIZER_MANGO_ACCOUNT
         }
     }
 }

--- a/common/src/config/strategy/ray.rs
+++ b/common/src/config/strategy/ray.rs
@@ -8,7 +8,7 @@ use crate::config::deposit_tracking::traits::{
 };
 use crate::config::deposit_tracking::withdraw::WithdrawDepositTrackingAddresses;
 use crate::config::strategy::traits::WithdrawMultiOptimizerVault;
-use crate::config::strategy::withdraw::{PlatformConfigAddresses, WithdrawAddresses};
+use crate::config::strategy::withdraw::WithdrawAddresses;
 use crate::config::strategy::Platform;
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program;

--- a/common/src/config/strategy/ray.rs
+++ b/common/src/config/strategy/ray.rs
@@ -18,6 +18,8 @@ use crate::config::deposit_tracking::issue_shares::DepositAddressesPermissioned;
 /// bundles configuration information for the usdc lending optimizer multi deposit vault
 
 pub mod multi_deposit {
+    use crate::config::strategy::traits::MultiVaultProgramConfig;
+
     use super::*;
 
     /// empty struct used to implement the various traits used
@@ -156,6 +158,64 @@ pub mod multi_deposit {
                 super::mango::GROUP_TOKEN_ACCOUNT,
                 super::mango::GROUP_SIGNER,
             ]
+        }
+    }
+    impl MultiVaultProgramConfig for ProgramConfig {
+        fn account(&self, ) -> Pubkey {
+            ACCOUNT
+        }
+        fn pda(&self, ) -> Pubkey {
+            PDA
+        }
+        fn shares_mint(&self, ) -> Pubkey {
+            SHARES_MINT
+        }
+        fn underlying_compound_queue(&self, ) -> Pubkey {
+            UNDERLYING_COMPOUND_QUEUE
+        }
+        fn underlying_deposit_queue(&self, ) -> Pubkey {
+            UNDERLYING_DEPOSIT_QUEUE
+        }
+        fn underlying_withdraw_queue(&self, ) -> Pubkey {
+            UNDERLYING_WITHDRAW_QUEUE
+        }
+        fn underlying_mint(&self, ) -> Pubkey {
+            UNDERLYING_MINT
+        }
+        fn rebalance_state_transition(&self, ) -> Pubkey {
+            REBALANCE_STATE_TRANSITION
+        }
+        fn rebalance_state_transition_underlying(&self, ) -> Pubkey {
+            REBALANCE_STATE_TRANSITION_UNDERLYING
+        }
+        fn optimizer_shares_account(&self, platform: Platform) -> Pubkey {
+            match platform {
+                Platform::MangoV3 => MANGO_OPTIMIZER_SHARES_ACCOUNT,
+                Platform::Solend => SOLEND_OPTIMIZER_SHARES_ACCOUNT,
+                Platform::Tulip => TULIP_OPTIMIZER_SHARES_ACCOUNT
+            }
+        }
+        fn issue_shares(&self, user: Pubkey) -> Box<dyn IssueShares> {
+            Box::new(ProgramConfig::issue_shares_ix(user))
+        }
+        fn permissioned_issue_shares(&self, user: Pubkey) -> Box<dyn IssueShares> {
+            Box::new(ProgramConfig::permissioned_issue_shares_ix(user))
+        }
+        fn register_deposit_tracking(&self, user: Pubkey) -> Box<dyn RegisterDepositTracking> {
+            Box::new(ProgramConfig::register_deposit_tracking_ix(user))
+        }
+        fn withdraw_deposit_tracking(&self, user: Pubkey) -> Box<dyn WithdrawDepositTracking> {
+            Box::new( ProgramConfig::withdraw_deposit_tracking_ix(user))
+        }
+        fn withdraw_multi_deposit_optimizer_vault(&self, user: Pubkey, platform: Platform) -> std::result::Result<Box<dyn WithdrawMultiOptimizerVault>, std::io::Error> {
+            Ok(ProgramConfig::withdraw_multi_deposit_optimizer_vault(user, platform)?)
+        }
+        fn remaining_accounts(&self, platform: Platform) -> Vec<Pubkey> {
+            match platform {
+                Platform::MangoV3 => ProgramConfig::get_mango_remaining_accounts().to_vec(),
+                Platform::Solend => ProgramConfig::get_solend_remaining_accounts().to_vec(),
+                Platform::Tulip => ProgramConfig::get_tulip_remaining_accounts().to_vec(),
+            }
         }
     }
 }

--- a/common/src/config/strategy/sol.rs
+++ b/common/src/config/strategy/sol.rs
@@ -16,6 +16,8 @@ use tulipv2_sdk_farms::{lending::Lending, Farm};
 use crate::config::deposit_tracking::issue_shares::DepositAddressesPermissioned;
 /// bundles configuration information for the usdc lending optimizer multi deposit vault
 pub mod multi_deposit {
+    use crate::config::strategy::traits::MultiVaultProgramConfig;
+
     use super::*;
     /// empty struct used to implement the various traits used
     /// to interact with the sol lending optimizer vault
@@ -153,6 +155,64 @@ pub mod multi_deposit {
                 super::mango::GROUP_TOKEN_ACCOUNT,
                 super::mango::GROUP_SIGNER,
             ]
+        }
+    }
+    impl MultiVaultProgramConfig for ProgramConfig {
+        fn account(&self, ) -> Pubkey {
+            ACCOUNT
+        }
+        fn pda(&self, ) -> Pubkey {
+            PDA
+        }
+        fn shares_mint(&self, ) -> Pubkey {
+            SHARES_MINT
+        }
+        fn underlying_compound_queue(&self, ) -> Pubkey {
+            UNDERLYING_COMPOUND_QUEUE
+        }
+        fn underlying_deposit_queue(&self, ) -> Pubkey {
+            UNDERLYING_DEPOSIT_QUEUE
+        }
+        fn underlying_withdraw_queue(&self, ) -> Pubkey {
+            UNDERLYING_WITHDRAW_QUEUE
+        }
+        fn underlying_mint(&self, ) -> Pubkey {
+            UNDERLYING_MINT
+        }
+        fn rebalance_state_transition(&self, ) -> Pubkey {
+            REBALANCE_STATE_TRANSITION
+        }
+        fn rebalance_state_transition_underlying(&self, ) -> Pubkey {
+            REBALANCE_STATE_TRANSITION_UNDERLYING
+        }
+        fn optimizer_shares_account(&self, platform: Platform) -> Pubkey {
+            match platform {
+                Platform::MangoV3 => MANGO_OPTIMIZER_SHARES_ACCOUNT,
+                Platform::Solend => SOLEND_OPTIMIZER_SHARES_ACCOUNT,
+                Platform::Tulip => TULIP_OPTIMIZER_SHARES_ACCOUNT
+            }
+        }
+        fn issue_shares(&self, user: Pubkey) -> Box<dyn IssueShares> {
+            Box::new(ProgramConfig::issue_shares_ix(user))
+        }
+        fn permissioned_issue_shares(&self, user: Pubkey) -> Box<dyn IssueShares> {
+            Box::new(ProgramConfig::permissioned_issue_shares_ix(user))
+        }
+        fn register_deposit_tracking(&self, user: Pubkey) -> Box<dyn RegisterDepositTracking> {
+            Box::new(ProgramConfig::register_deposit_tracking_ix(user))
+        }
+        fn withdraw_deposit_tracking(&self, user: Pubkey) -> Box<dyn WithdrawDepositTracking> {
+            Box::new( ProgramConfig::withdraw_deposit_tracking_ix(user))
+        }
+        fn withdraw_multi_deposit_optimizer_vault(&self, user: Pubkey, platform: Platform) -> std::result::Result<Box<dyn WithdrawMultiOptimizerVault>, std::io::Error> {
+            Ok(ProgramConfig::withdraw_multi_deposit_optimizer_vault(user, platform)?)
+        }
+        fn remaining_accounts(&self, platform: Platform) -> Vec<Pubkey> {
+            match platform {
+                Platform::MangoV3 => ProgramConfig::get_mango_remaining_accounts().to_vec(),
+                Platform::Solend => ProgramConfig::get_solend_remaining_accounts().to_vec(),
+                Platform::Tulip => ProgramConfig::get_tulip_remaining_accounts().to_vec(),
+            }
         }
     }
 }

--- a/common/src/config/strategy/sol.rs
+++ b/common/src/config/strategy/sol.rs
@@ -8,7 +8,7 @@ use crate::config::deposit_tracking::traits::{
 };
 use crate::config::deposit_tracking::withdraw::WithdrawDepositTrackingAddresses;
 use crate::config::strategy::traits::WithdrawMultiOptimizerVault;
-use crate::config::strategy::withdraw::{PlatformConfigAddresses, WithdrawAddresses};
+use crate::config::strategy::withdraw::WithdrawAddresses;
 use crate::config::strategy::Platform;
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program;

--- a/common/src/config/strategy/traits.rs
+++ b/common/src/config/strategy/traits.rs
@@ -3,6 +3,10 @@
 use anchor_lang::prelude::*;
 use solana_program::instruction::Instruction;
 
+use crate::config::deposit_tracking::traits::{IssueShares, RegisterDepositTracking};
+use crate::config::deposit_tracking::traits::WithdrawDepositTracking;
+use super::Platform;
+
 /// The `WithdrawMultiOptimizerVault` trait is used to
 /// burn a lending optimizer's tokenized shares, in exchange
 /// for the underlying asset backing the burned amount.
@@ -122,4 +126,134 @@ pub trait WithdrawMultiOptimizerVault {
     /// please note the _is_signer variable is ignored, it's simply here to provide
     /// compatibility
     fn to_account_meta(&self, _is_signer: Option<bool>) -> Vec<AccountMeta>;
+}
+
+/// trait type that is used to return configuration information, instruction helpers, etc...
+/// for any given multi deposit optimizer vault, aka strategy vault. 
+pub trait MultiVaultProgramConfig {
+    fn account(&self) -> Pubkey;
+    fn pda(&self) -> Pubkey;
+    fn shares_mint(&self) -> Pubkey;
+    fn underlying_compound_queue(&self) -> Pubkey;
+    fn underlying_deposit_queue(&self) -> Pubkey;
+    fn underlying_withdraw_queue(&self) -> Pubkey;
+    fn underlying_mint(&self) -> Pubkey;
+    fn rebalance_state_transition(&self) -> Pubkey;
+    fn rebalance_state_transition_underlying(&self) -> Pubkey;
+    fn optimizer_shares_account(&self, platform: Platform) -> Pubkey;
+    fn issue_shares(&self, user: Pubkey) -> Box<dyn IssueShares>;
+    fn permissioned_issue_shares(&self, user: Pubkey) -> Box<dyn IssueShares>;
+    fn register_deposit_tracking(&self, user: Pubkey) -> Box<dyn RegisterDepositTracking>;
+    fn withdraw_deposit_tracking(&self, user: Pubkey) -> Box<dyn WithdrawDepositTracking>;
+    fn withdraw_multi_deposit_optimizer_vault(&self, user: Pubkey, platform: Platform) -> std::result::Result<Box<dyn WithdrawMultiOptimizerVault>, std::io::Error>;
+    /// returns the remaining accounts needed for withdrawal instructions to the specific platform
+    fn remaining_accounts(&self, platform: Platform) -> Vec<Pubkey>;
+}
+
+
+/// Trait type that is used to return configuration information, instruction helpers, etc...
+/// for a single standalone vault.
+pub trait StandaloneVaultProgramConfig {
+    /// returns the address of the standalone vault account
+    fn account() -> Pubkey;
+    /// returns the address of the standalone vault pda
+    fn pda() -> Pubkey;
+    /// returns the address of the standalone vault shares mint
+    fn shares_mint() -> Pubkey;
+    /// returns the address of the standalone vault underlying compound queue
+    fn underlying_compound_queue() -> Pubkey;
+    /// returns the address of the standalone vault underlying deposit queue
+    fn underlying_deposit_queue() -> Pubkey;
+    /// returns the address of the standalone vault underlying withdraw queue
+    fn underlying_withdraw_queue() -> Pubkey;
+    /// returns the address of the standalone vault underlying token mint
+    /// which is the mint of the token the vault accepts for deposits
+    fn underlying_mint() -> Pubkey;
+    /// returns the address of configuration data account
+    fn config_data_account() -> Pubkey;
+    /// returns the address of the configuration information account
+    fn information_account() -> Pubkey;
+    /// returns the address of the program this standalone vault farms. for example
+    /// solend standalone vaults will return the address of the solend lending program
+    /// while mango standalone vaults will return the address of the mango program
+    fn program_id() -> Pubkey;
+    /// when the implementation of this trait is a solend standalone vault
+    /// calling this method returns Some(...)
+    fn solend_config() -> Option<Box<dyn SolendProgramConfig>>;
+    /// when the implementation of this trait is a tulip standalone vault
+    /// calling this method returns Some(...)
+    fn tulip_config() -> Option<Box<dyn TulipProgramConfig>>;
+    /// when the implementation of this trait is a mango standalone vault
+    /// calling this method returns Some(...)
+    fn mango_config() -> Option<Box<dyn MangoProgramConfig>>;
+    /// returns true if the instance of the implementation of this trait is a platform
+    /// matching the one specified in `platform`, otherwise returns false
+    fn is_platform(platform: Platform) -> bool;
+}
+
+/// Trait type that is used to return configuration information, instruction helpers, etc..
+/// for solend standalone vaults
+pub trait SolendProgramConfig {
+    /// returns the address of the collateral mint issued by the lending reserve
+    fn collateral_mint(&self) -> Pubkey;
+    /// returns the lending market that the reserve is a part of
+    fn lending_market(&self) -> Pubkey;
+    /// returns the authority of the lending market
+    fn lending_market_authority(&self) -> Pubkey;
+    /// returns the pyth price feed account 
+    fn pyth_price_account(&self) -> Pubkey;
+    /// returns the switchboard price account
+    fn switchboard_price_account(&self) -> Pubkey;
+    /// returns the address of the pyth oracle program
+    fn pyth_program_id(&self) -> Pubkey;
+    /// returns the address of the switchboard oracle program
+    fn switchboard_program_id(&self) -> Pubkey;
+    /// returns the address of the lending reserve deposits go into
+    fn reserve(&self) -> Pubkey;
+    /// returns the token account the reserve uses to hold deposited liquidity
+    fn reserve_liquidity(&self) -> Pubkey;
+    /// the solend standalone vault's collateral token account
+    fn vault_collateral_account(&self) -> Pubkey;
+}
+
+/// Trait type that is used to return configuration information, instruction helpers, etc..
+/// for solend tulip vaults
+pub trait TulipProgramConfig {
+    /// returns the address of the collateral mint issued by the lending reserve
+    fn collateral_mint(&self) -> Pubkey;
+    /// returns the lending market that the reserve is a part of
+    fn lending_market(&self) -> Pubkey;
+    /// returns the authority of the lending market
+    fn lending_market_authority(&self) -> Pubkey;
+    /// returns the pyth price feed account 
+    fn pyth_price_account(&self) -> Pubkey;
+    /// returns the address of the pyth oracle program
+    fn pyth_program_id(&self) -> Pubkey;
+    /// returns the address of the lending reserve deposits go into
+    fn reserve(&self) -> Pubkey;
+    /// returns the token account the reserve uses to hold deposited liquidity
+    fn reserve_liquidity(&self) -> Pubkey;
+    /// the tulip standalone vault's collateral token account
+    fn vault_collateral_account(&self) -> Pubkey;
+}
+
+/// Trait type that is used to return configuration information, instruction helpers, etc..
+/// for solend mango vaults
+pub trait MangoProgramConfig {
+    /// returns the address of the mango cache
+    fn cache(&self) -> Pubkey;
+    /// returns the address of the mango group
+    fn group(&self) -> Pubkey;
+    /// returns the address of the group authority
+    fn group_signer(&self) -> Pubkey;
+    /// returns the address of the group's token account which accepts the asset
+    /// being accepted by the strategy. for example usdc strategy vaults, this will be the mango
+    /// group's usdc token account
+    fn group_token_account(&self) -> Pubkey;
+    /// returns the address of the mango root bank
+    fn root_bank(&self) -> Pubkey;
+    /// returns the address of the mango node bank
+    fn node_bank(&self) -> Pubkey;
+    /// address of the standalone vaults mango account
+    fn optimizer_mango_account(&self) -> Pubkey;
 }

--- a/common/src/config/strategy/usdc.rs
+++ b/common/src/config/strategy/usdc.rs
@@ -17,6 +17,8 @@ use crate::config::deposit_tracking::issue_shares::DepositAddressesPermissioned;
 
 /// bundles configuration information for the usdc lending optimizer multi deposit vault
 pub mod multi_deposit {
+    use crate::config::strategy::traits::MultiVaultProgramConfig;
+
     use super::*;
 
     /// empty struct used to implement the various traits used
@@ -158,6 +160,65 @@ pub mod multi_deposit {
                 super::mango::GROUP_TOKEN_ACCOUNT,
                 super::mango::GROUP_SIGNER,
             ]
+        }
+    }
+
+    impl MultiVaultProgramConfig for ProgramConfig {
+        fn account(&self, ) -> Pubkey {
+            ACCOUNT
+        }
+        fn pda(&self, ) -> Pubkey {
+            PDA
+        }
+        fn shares_mint(&self, ) -> Pubkey {
+            SHARES_MINT
+        }
+        fn underlying_compound_queue(&self, ) -> Pubkey {
+            UNDERLYING_COMPOUND_QUEUE
+        }
+        fn underlying_deposit_queue(&self, ) -> Pubkey {
+            UNDERLYING_DEPOSIT_QUEUE
+        }
+        fn underlying_withdraw_queue(&self, ) -> Pubkey {
+            UNDERLYING_WITHDRAW_QUEUE
+        }
+        fn underlying_mint(&self, ) -> Pubkey {
+            UNDERLYING_MINT
+        }
+        fn rebalance_state_transition(&self, ) -> Pubkey {
+            REBALANCE_STATE_TRANSITION
+        }
+        fn rebalance_state_transition_underlying(&self, ) -> Pubkey {
+            REBALANCE_STATE_TRANSITION_UNDERLYING
+        }
+        fn optimizer_shares_account(&self, platform: Platform) -> Pubkey {
+            match platform {
+                Platform::MangoV3 => MANGO_OPTIMIZER_SHARES_ACCOUNT,
+                Platform::Solend => SOLEND_OPTIMIZER_SHARES_ACCOUNT,
+                Platform::Tulip => TULIP_OPTIMIZER_SHARES_ACCOUNT
+            }
+        }
+        fn issue_shares(&self, user: Pubkey) -> Box<dyn IssueShares> {
+            Box::new(ProgramConfig::issue_shares_ix(user))
+        }
+        fn permissioned_issue_shares(&self, user: Pubkey) -> Box<dyn IssueShares> {
+            Box::new(ProgramConfig::permissioned_issue_shares_ix(user))
+        }
+        fn register_deposit_tracking(&self, user: Pubkey) -> Box<dyn RegisterDepositTracking> {
+            Box::new(ProgramConfig::register_deposit_tracking_ix(user))
+        }
+        fn withdraw_deposit_tracking(&self, user: Pubkey) -> Box<dyn WithdrawDepositTracking> {
+            Box::new( ProgramConfig::withdraw_deposit_tracking_ix(user))
+        }
+        fn withdraw_multi_deposit_optimizer_vault(&self, user: Pubkey, platform: Platform) -> std::result::Result<Box<dyn WithdrawMultiOptimizerVault>, std::io::Error> {
+            Ok(ProgramConfig::withdraw_multi_deposit_optimizer_vault(user, platform)?)
+        }
+        fn remaining_accounts(&self, platform: Platform) -> Vec<Pubkey> {
+            match platform {
+                Platform::MangoV3 => ProgramConfig::get_mango_remaining_accounts().to_vec(),
+                Platform::Solend => ProgramConfig::get_solend_remaining_accounts().to_vec(),
+                Platform::Tulip => ProgramConfig::get_tulip_remaining_accounts().to_vec(),
+            }
         }
     }
 }

--- a/common/src/config/strategy/usdc.rs
+++ b/common/src/config/strategy/usdc.rs
@@ -1,6 +1,7 @@
 //! usdc lending optimizer configuration variables
 
 use crate::config::deposit_tracking::issue_shares::DepositAddresses;
+use crate::config::deposit_tracking::issue_shares::DepositAddressesPermissioned;
 use crate::config::deposit_tracking::register::RegisterDepositTrackingAddresses;
 use crate::config::deposit_tracking::traits::{
     IssueShares, RegisterDepositTracking, WithdrawDepositTracking,
@@ -13,16 +14,16 @@ use anchor_lang::prelude::*;
 use anchor_lang::solana_program;
 use static_pubkey::static_pubkey;
 use tulipv2_sdk_farms::{lending::Lending, Farm};
-use crate::config::deposit_tracking::issue_shares::DepositAddressesPermissioned;
 
 /// bundles configuration information for the usdc lending optimizer multi deposit vault
 pub mod multi_deposit {
-    use crate::config::strategy::traits::MultiVaultProgramConfig;
+    use crate::config::strategy::traits::{MultiVaultProgramConfig, StandaloneVaultProgramConfig};
 
     use super::*;
 
     /// empty struct used to implement the various traits used
     /// to interact with the usdt lending optimizer vault
+    #[derive(Clone, Copy)]
     pub struct ProgramConfig;
 
     pub const TAG_STRING: &str = "usdcv1";
@@ -164,38 +165,38 @@ pub mod multi_deposit {
     }
 
     impl MultiVaultProgramConfig for ProgramConfig {
-        fn account(&self, ) -> Pubkey {
+        fn account(&self) -> Pubkey {
             ACCOUNT
         }
-        fn pda(&self, ) -> Pubkey {
+        fn pda(&self) -> Pubkey {
             PDA
         }
-        fn shares_mint(&self, ) -> Pubkey {
+        fn shares_mint(&self) -> Pubkey {
             SHARES_MINT
         }
-        fn underlying_compound_queue(&self, ) -> Pubkey {
+        fn underlying_compound_queue(&self) -> Pubkey {
             UNDERLYING_COMPOUND_QUEUE
         }
-        fn underlying_deposit_queue(&self, ) -> Pubkey {
+        fn underlying_deposit_queue(&self) -> Pubkey {
             UNDERLYING_DEPOSIT_QUEUE
         }
-        fn underlying_withdraw_queue(&self, ) -> Pubkey {
+        fn underlying_withdraw_queue(&self) -> Pubkey {
             UNDERLYING_WITHDRAW_QUEUE
         }
-        fn underlying_mint(&self, ) -> Pubkey {
+        fn underlying_mint(&self) -> Pubkey {
             UNDERLYING_MINT
         }
-        fn rebalance_state_transition(&self, ) -> Pubkey {
+        fn rebalance_state_transition(&self) -> Pubkey {
             REBALANCE_STATE_TRANSITION
         }
-        fn rebalance_state_transition_underlying(&self, ) -> Pubkey {
+        fn rebalance_state_transition_underlying(&self) -> Pubkey {
             REBALANCE_STATE_TRANSITION_UNDERLYING
         }
         fn optimizer_shares_account(&self, platform: Platform) -> Pubkey {
             match platform {
                 Platform::MangoV3 => MANGO_OPTIMIZER_SHARES_ACCOUNT,
                 Platform::Solend => SOLEND_OPTIMIZER_SHARES_ACCOUNT,
-                Platform::Tulip => TULIP_OPTIMIZER_SHARES_ACCOUNT
+                Platform::Tulip => TULIP_OPTIMIZER_SHARES_ACCOUNT,
             }
         }
         fn issue_shares(&self, user: Pubkey) -> Box<dyn IssueShares> {
@@ -208,10 +209,16 @@ pub mod multi_deposit {
             Box::new(ProgramConfig::register_deposit_tracking_ix(user))
         }
         fn withdraw_deposit_tracking(&self, user: Pubkey) -> Box<dyn WithdrawDepositTracking> {
-            Box::new( ProgramConfig::withdraw_deposit_tracking_ix(user))
+            Box::new(ProgramConfig::withdraw_deposit_tracking_ix(user))
         }
-        fn withdraw_multi_deposit_optimizer_vault(&self, user: Pubkey, platform: Platform) -> std::result::Result<Box<dyn WithdrawMultiOptimizerVault>, std::io::Error> {
-            Ok(ProgramConfig::withdraw_multi_deposit_optimizer_vault(user, platform)?)
+        fn withdraw_multi_deposit_optimizer_vault(
+            &self,
+            user: Pubkey,
+            platform: Platform,
+        ) -> std::result::Result<Box<dyn WithdrawMultiOptimizerVault>, std::io::Error> {
+            Ok(ProgramConfig::withdraw_multi_deposit_optimizer_vault(
+                user, platform,
+            )?)
         }
         fn remaining_accounts(&self, platform: Platform) -> Vec<Pubkey> {
             match platform {
@@ -220,19 +227,40 @@ pub mod multi_deposit {
                 Platform::Tulip => ProgramConfig::get_tulip_remaining_accounts().to_vec(),
             }
         }
+        fn standalone_config(&self, platform: Platform) -> Box<dyn StandaloneVaultProgramConfig> {
+            match platform {
+                Platform::MangoV3 => Box::new(mango::ProgramConfig),
+                Platform::Solend => Box::new(solend::ProgramConfig),
+                Platform::Tulip => Box::new(tulip::ProgramConfig),
+            }
+        }
+        fn farm(&self) -> Farm {
+            FARM_KEY
+        }
+        fn tag(&self) -> &str {
+            TAG_STRING
+        }
     }
 }
 
 /// bundles configuration information for the solend usdc standalone vault
 pub mod solend {
+    use crate::config::strategy::{
+        traits::{SolendProgramConfig, StandaloneVaultProgramConfig},
+        withdraw::PlatformConfigAddresses,
+        Platform,
+    };
 
-    use super::*;
+    use anchor_lang::solana_program::{self, pubkey::Pubkey};
+    use static_pubkey::static_pubkey;
+    use tulipv2_sdk_farms::{lending::Lending, Farm};
 
     pub const TAG_STRING: &str = "solend";
     pub const FARM_KEY: Farm = Farm::Lending {
         name: Lending::USDC,
     };
-
+    #[derive(Clone, Copy)]
+    pub struct ProgramConfig;
     /// address of the standalone vault itself
     pub const ACCOUNT: Pubkey = static_pubkey!("85JXjDiyianDpvz8y8efkRyFsxpnSJJpmyxrJ7bncKHM");
     /// address of the standalone vault pda
@@ -305,17 +333,115 @@ pub mod solend {
             lending_program: PROGRAM_ID,
         }
     }
+    impl StandaloneVaultProgramConfig for ProgramConfig {
+        fn account(&self) -> Pubkey {
+            ACCOUNT
+        }
+        fn pda(&self) -> Pubkey {
+            PDA
+        }
+        fn shares_mint(&self) -> Pubkey {
+            SHARES_MINT
+        }
+        fn underlying_compound_queue(&self) -> Pubkey {
+            UNDERLYING_COMPOUND_QUEUE
+        }
+        fn underlying_deposit_queue(&self) -> Pubkey {
+            UNDERLYING_DEPOSIT_QUEUE
+        }
+        fn underlying_withdraw_queue(&self) -> Pubkey {
+            UNDERLYING_WITHDRAW_QUEUE
+        }
+        fn underlying_mint(&self) -> Pubkey {
+            UNDERLYING_MINT
+        }
+        fn config_data_account(&self) -> Pubkey {
+            CONFIG_DATA_ACCOUNT
+        }
+        fn information_account(&self) -> Pubkey {
+            INFORMATION_ACCOUNT
+        }
+        fn program_id(&self) -> Pubkey {
+            PROGRAM_ID
+        }
+        fn solend_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::SolendProgramConfig>> {
+            Some(Box::new(*self))
+        }
+        fn tulip_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::TulipProgramConfig>> {
+            None
+        }
+        fn mango_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::MangoProgramConfig>> {
+            None
+        }
+        fn is_platform(&self, platform: Platform) -> bool {
+            matches!(platform, Platform::Solend)
+        }
+        fn farm(&self) -> Farm {
+            FARM_KEY
+        }
+        fn tag(&self) -> &str {
+            TAG_STRING
+        }
+    }
+    impl SolendProgramConfig for ProgramConfig {
+        fn collateral_mint(&self) -> Pubkey {
+            COLLATERAL_MINT
+        }
+        fn lending_market(&self) -> Pubkey {
+            LENDING_MARKET_ACCOUNT
+        }
+        fn lending_market_authority(&self) -> Pubkey {
+            LENDING_MARKET_AUTHORITY
+        }
+        fn pyth_price_account(&self) -> Pubkey {
+            PYTH_PRICE_ACCOUNT
+        }
+        fn switchboard_price_account(&self) -> Pubkey {
+            SWITCHBOARD_PRICE_ACCOUNT
+        }
+        fn pyth_program_id(&self) -> Pubkey {
+            PYTH_PROGRAM_ID
+        }
+        fn switchboard_program_id(&self) -> Pubkey {
+            SWITCHBOARD_PROGRAM_ID
+        }
+        fn reserve(&self) -> Pubkey {
+            RESERVE_ACCOUNT
+        }
+        fn reserve_liquidity(&self) -> Pubkey {
+            RESERVE_LIQUIDITY_ACCOUNT
+        }
+        fn vault_collateral_account(&self) -> Pubkey {
+            COLLATERAL_TOKEN_ACCOUNT
+        }
+    }
 }
 
 /// bundles configuration information for the tulip usdc standalone vault
 pub mod tulip {
+    use crate::config::strategy::{
+        traits::{StandaloneVaultProgramConfig, TulipProgramConfig},
+        withdraw::PlatformConfigAddresses,
+        Platform,
+    };
 
-    use super::*;
+    use anchor_lang::solana_program::{self, pubkey::Pubkey};
+    use static_pubkey::static_pubkey;
+    use tulipv2_sdk_farms::{lending::Lending, Farm};
 
     pub const TAG_STRING: &str = "tulip";
     pub const FARM_KEY: Farm = Farm::Lending {
         name: Lending::USDC,
     };
+
+    #[derive(Clone, Copy)]
+    pub struct ProgramConfig;
 
     /// address of the standalone vault itself
     pub const ACCOUNT: Pubkey = static_pubkey!("8KLrrsnUv3DjC9Q89xSQDVdiGLZHUEUuyPedfHrtuVRr");
@@ -382,16 +508,109 @@ pub mod tulip {
             lending_program: PROGRAM_ID,
         }
     }
+    impl StandaloneVaultProgramConfig for ProgramConfig {
+        fn account(&self) -> Pubkey {
+            ACCOUNT
+        }
+        fn pda(&self) -> Pubkey {
+            PDA
+        }
+        fn shares_mint(&self) -> Pubkey {
+            SHARES_MINT
+        }
+        fn underlying_compound_queue(&self) -> Pubkey {
+            UNDERLYING_COMPOUND_QUEUE
+        }
+        fn underlying_deposit_queue(&self) -> Pubkey {
+            UNDERLYING_DEPOSIT_QUEUE
+        }
+        fn underlying_withdraw_queue(&self) -> Pubkey {
+            UNDERLYING_WITHDRAW_QUEUE
+        }
+        fn underlying_mint(&self) -> Pubkey {
+            UNDERLYING_MINT
+        }
+        fn config_data_account(&self) -> Pubkey {
+            CONFIG_DATA_ACCOUNT
+        }
+        fn information_account(&self) -> Pubkey {
+            INFORMATION_ACCOUNT
+        }
+        fn program_id(&self) -> Pubkey {
+            PROGRAM_ID
+        }
+        fn solend_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::SolendProgramConfig>> {
+            None
+        }
+        fn tulip_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::TulipProgramConfig>> {
+            Some(Box::new(*self))
+        }
+        fn mango_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::MangoProgramConfig>> {
+            None
+        }
+        fn is_platform(&self, platform: Platform) -> bool {
+            matches!(platform, Platform::Tulip)
+        }
+        fn farm(&self) -> Farm {
+            FARM_KEY
+        }
+        fn tag(&self) -> &str {
+            TAG_STRING
+        }
+    }
+    impl TulipProgramConfig for ProgramConfig {
+        fn collateral_mint(&self) -> Pubkey {
+            COLLATERAL_MINT
+        }
+        fn lending_market(&self) -> Pubkey {
+            LENDING_MARKET_ACCOUNT
+        }
+        fn lending_market_authority(&self) -> Pubkey {
+            LENDING_MARKET_AUTHORITY
+        }
+        fn pyth_price_account(&self) -> Pubkey {
+            PYTH_PRICE_ACCOUNT
+        }
+        fn pyth_program_id(&self) -> Pubkey {
+            PYTH_PROGRAM_ID
+        }
+        fn reserve(&self) -> Pubkey {
+            RESERVE_ACCOUNT
+        }
+        fn reserve_liquidity(&self) -> Pubkey {
+            RESERVE_LIQUIDITY_ACCOUNT
+        }
+        fn vault_collateral_account(&self) -> Pubkey {
+            COLLATERAL_TOKEN_ACCOUNT
+        }
+    }
 }
 
 /// bundles configuration information for the mango usdc standalone vault
 pub mod mango {
-    use super::*;
+    use crate::config::strategy::{
+        traits::{MangoProgramConfig, StandaloneVaultProgramConfig},
+        withdraw::PlatformConfigAddresses,
+        Platform,
+    };
+
+    use anchor_lang::solana_program::{self, pubkey::Pubkey};
+    use static_pubkey::static_pubkey;
+    use tulipv2_sdk_farms::{lending::Lending, Farm};
 
     pub const TAG_STRING: &str = "mango";
     pub const FARM_KEY: Farm = Farm::Lending {
         name: Lending::USDC,
     };
+
+    #[derive(Clone, Copy)]
+    pub struct ProgramConfig;
 
     /// address of the standalone vault itself
     pub const ACCOUNT: Pubkey = static_pubkey!("ZH9GWNBtwxcWeU9kHk77DSciwQnoJcSm8VVvYfmHXfe");
@@ -444,6 +663,85 @@ pub mod mango {
             shares_mint: SHARES_MINT,
             underlying_deposit_queue: UNDERLYING_DEPOSIT_QUEUE,
             lending_program: PROGRAM_ID,
+        }
+    }
+    impl StandaloneVaultProgramConfig for ProgramConfig {
+        fn account(&self) -> Pubkey {
+            ACCOUNT
+        }
+        fn pda(&self) -> Pubkey {
+            PDA
+        }
+        fn shares_mint(&self) -> Pubkey {
+            SHARES_MINT
+        }
+        fn underlying_compound_queue(&self) -> Pubkey {
+            UNDERLYING_COMPOUND_QUEUE
+        }
+        fn underlying_deposit_queue(&self) -> Pubkey {
+            UNDERLYING_DEPOSIT_QUEUE
+        }
+        fn underlying_withdraw_queue(&self) -> Pubkey {
+            UNDERLYING_WITHDRAW_QUEUE
+        }
+        fn underlying_mint(&self) -> Pubkey {
+            UNDERLYING_MINT
+        }
+        fn config_data_account(&self) -> Pubkey {
+            CONFIG_DATA_ACCOUNT
+        }
+        fn information_account(&self) -> Pubkey {
+            INFORMATION_ACCOUNT
+        }
+        fn program_id(&self) -> Pubkey {
+            PROGRAM_ID
+        }
+        fn solend_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::SolendProgramConfig>> {
+            None
+        }
+        fn tulip_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::TulipProgramConfig>> {
+            None
+        }
+        fn mango_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::MangoProgramConfig>> {
+            Some(Box::new(*self))
+        }
+        fn is_platform(&self, platform: Platform) -> bool {
+            matches!(platform, Platform::MangoV3)
+        }
+        fn farm(&self) -> Farm {
+            FARM_KEY
+        }
+        fn tag(&self) -> &str {
+            TAG_STRING
+        }
+    }
+    impl MangoProgramConfig for ProgramConfig {
+        fn cache(&self) -> Pubkey {
+            CACHE
+        }
+        fn group(&self) -> Pubkey {
+            GROUP
+        }
+        fn group_signer(&self) -> Pubkey {
+            GROUP_SIGNER
+        }
+        fn group_token_account(&self) -> Pubkey {
+            GROUP_TOKEN_ACCOUNT
+        }
+        fn root_bank(&self) -> Pubkey {
+            ROOT_BANK
+        }
+        fn node_bank(&self) -> Pubkey {
+            NODE_BANK
+        }
+        fn optimizer_mango_account(&self) -> Pubkey {
+            OPTIMIZER_MANGO_ACCOUNT
         }
     }
 }

--- a/common/src/config/strategy/usdc.rs
+++ b/common/src/config/strategy/usdc.rs
@@ -8,7 +8,7 @@ use crate::config::deposit_tracking::traits::{
 };
 use crate::config::deposit_tracking::withdraw::WithdrawDepositTrackingAddresses;
 use crate::config::strategy::traits::WithdrawMultiOptimizerVault;
-use crate::config::strategy::withdraw::{PlatformConfigAddresses, WithdrawAddresses};
+use crate::config::strategy::withdraw::WithdrawAddresses;
 use crate::config::strategy::Platform;
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program;

--- a/common/src/config/strategy/usdt.rs
+++ b/common/src/config/strategy/usdt.rs
@@ -1,6 +1,7 @@
 //! usdc lending optimizer configuration variables
 
 use crate::config::deposit_tracking::issue_shares::DepositAddresses;
+use crate::config::deposit_tracking::issue_shares::DepositAddressesPermissioned;
 use crate::config::deposit_tracking::register::RegisterDepositTrackingAddresses;
 use crate::config::deposit_tracking::traits::{
     IssueShares, RegisterDepositTracking, WithdrawDepositTracking,
@@ -13,17 +14,17 @@ use anchor_lang::prelude::*;
 use anchor_lang::solana_program;
 use static_pubkey::static_pubkey;
 use tulipv2_sdk_farms::{lending::Lending, Farm};
-use crate::config::deposit_tracking::issue_shares::DepositAddressesPermissioned;
 
 /// bundles configuration information for the usdc lending optimizer multi deposit vault
 pub mod multi_deposit {
 
-    use crate::config::strategy::traits::MultiVaultProgramConfig;
+    use crate::config::strategy::traits::{MultiVaultProgramConfig, StandaloneVaultProgramConfig};
 
     use super::*;
 
     /// empty struct used to implement the various traits used
     /// to interact with the usdt lending optimizer vault
+    #[derive(Clone, Copy)]
     pub struct ProgramConfig;
 
     pub const TAG_STRING: &str = "usdtv1";
@@ -164,38 +165,38 @@ pub mod multi_deposit {
         }
     }
     impl MultiVaultProgramConfig for ProgramConfig {
-        fn account(&self, ) -> Pubkey {
+        fn account(&self) -> Pubkey {
             ACCOUNT
         }
-        fn pda(&self, ) -> Pubkey {
+        fn pda(&self) -> Pubkey {
             PDA
         }
-        fn shares_mint(&self, ) -> Pubkey {
+        fn shares_mint(&self) -> Pubkey {
             SHARES_MINT
         }
-        fn underlying_compound_queue(&self, ) -> Pubkey {
+        fn underlying_compound_queue(&self) -> Pubkey {
             UNDERLYING_COMPOUND_QUEUE
         }
-        fn underlying_deposit_queue(&self, ) -> Pubkey {
+        fn underlying_deposit_queue(&self) -> Pubkey {
             UNDERLYING_DEPOSIT_QUEUE
         }
-        fn underlying_withdraw_queue(&self, ) -> Pubkey {
+        fn underlying_withdraw_queue(&self) -> Pubkey {
             UNDERLYING_WITHDRAW_QUEUE
         }
-        fn underlying_mint(&self, ) -> Pubkey {
+        fn underlying_mint(&self) -> Pubkey {
             UNDERLYING_MINT
         }
-        fn rebalance_state_transition(&self, ) -> Pubkey {
+        fn rebalance_state_transition(&self) -> Pubkey {
             REBALANCE_STATE_TRANSITION
         }
-        fn rebalance_state_transition_underlying(&self, ) -> Pubkey {
+        fn rebalance_state_transition_underlying(&self) -> Pubkey {
             REBALANCE_STATE_TRANSITION_UNDERLYING
         }
         fn optimizer_shares_account(&self, platform: Platform) -> Pubkey {
             match platform {
                 Platform::MangoV3 => MANGO_OPTIMIZER_SHARES_ACCOUNT,
                 Platform::Solend => SOLEND_OPTIMIZER_SHARES_ACCOUNT,
-                Platform::Tulip => TULIP_OPTIMIZER_SHARES_ACCOUNT
+                Platform::Tulip => TULIP_OPTIMIZER_SHARES_ACCOUNT,
             }
         }
         fn issue_shares(&self, user: Pubkey) -> Box<dyn IssueShares> {
@@ -208,10 +209,16 @@ pub mod multi_deposit {
             Box::new(ProgramConfig::register_deposit_tracking_ix(user))
         }
         fn withdraw_deposit_tracking(&self, user: Pubkey) -> Box<dyn WithdrawDepositTracking> {
-            Box::new( ProgramConfig::withdraw_deposit_tracking_ix(user))
+            Box::new(ProgramConfig::withdraw_deposit_tracking_ix(user))
         }
-        fn withdraw_multi_deposit_optimizer_vault(&self, user: Pubkey, platform: Platform) -> std::result::Result<Box<dyn WithdrawMultiOptimizerVault>, std::io::Error> {
-            Ok(ProgramConfig::withdraw_multi_deposit_optimizer_vault(user, platform)?)
+        fn withdraw_multi_deposit_optimizer_vault(
+            &self,
+            user: Pubkey,
+            platform: Platform,
+        ) -> std::result::Result<Box<dyn WithdrawMultiOptimizerVault>, std::io::Error> {
+            Ok(ProgramConfig::withdraw_multi_deposit_optimizer_vault(
+                user, platform,
+            )?)
         }
         fn remaining_accounts(&self, platform: Platform) -> Vec<Pubkey> {
             match platform {
@@ -220,17 +227,34 @@ pub mod multi_deposit {
                 Platform::Tulip => ProgramConfig::get_tulip_remaining_accounts().to_vec(),
             }
         }
+        fn standalone_config(&self, platform: Platform) -> Box<dyn StandaloneVaultProgramConfig> {
+            match platform {
+                Platform::MangoV3 => Box::new(mango::ProgramConfig),
+                Platform::Solend => Box::new(solend::ProgramConfig),
+                Platform::Tulip => Box::new(tulip::ProgramConfig),
+            }
+        }
+        fn farm(&self) -> Farm {
+            FARM_KEY
+        }
+        fn tag(&self) -> &str {
+            TAG_STRING
+        }
     }
 }
 
 /// bundles configuration information for the solend usdc standalone vault
 pub mod solend {
     use super::*;
+    use crate::config::strategy::traits::{SolendProgramConfig, StandaloneVaultProgramConfig};
 
     pub const TAG_STRING: &str = "solend";
     pub const FARM_KEY: Farm = Farm::Lending {
         name: Lending::USDT,
     };
+
+    #[derive(Clone, Copy)]
+    pub struct ProgramConfig;
 
     /// address of the standalone vault itself
     pub const ACCOUNT: Pubkey = static_pubkey!("4YmXxV6C6MQs3TrZjpH5bw4qTtgZZhVRNfkWEteVXcWX");
@@ -304,16 +328,108 @@ pub mod solend {
             lending_program: PROGRAM_ID,
         }
     }
+    impl StandaloneVaultProgramConfig for ProgramConfig {
+        fn account(&self) -> Pubkey {
+            ACCOUNT
+        }
+        fn pda(&self) -> Pubkey {
+            PDA
+        }
+        fn shares_mint(&self) -> Pubkey {
+            SHARES_MINT
+        }
+        fn underlying_compound_queue(&self) -> Pubkey {
+            UNDERLYING_COMPOUND_QUEUE
+        }
+        fn underlying_deposit_queue(&self) -> Pubkey {
+            UNDERLYING_DEPOSIT_QUEUE
+        }
+        fn underlying_withdraw_queue(&self) -> Pubkey {
+            UNDERLYING_WITHDRAW_QUEUE
+        }
+        fn underlying_mint(&self) -> Pubkey {
+            UNDERLYING_MINT
+        }
+        fn config_data_account(&self) -> Pubkey {
+            CONFIG_DATA_ACCOUNT
+        }
+        fn information_account(&self) -> Pubkey {
+            INFORMATION_ACCOUNT
+        }
+        fn program_id(&self) -> Pubkey {
+            PROGRAM_ID
+        }
+        fn solend_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::SolendProgramConfig>> {
+            Some(Box::new(*self))
+        }
+        fn tulip_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::TulipProgramConfig>> {
+            None
+        }
+        fn mango_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::MangoProgramConfig>> {
+            None
+        }
+        fn is_platform(&self, platform: Platform) -> bool {
+            matches!(platform, Platform::Solend)
+        }
+        fn farm(&self) -> Farm {
+            FARM_KEY
+        }
+        fn tag(&self) -> &str {
+            TAG_STRING
+        }
+    }
+    impl SolendProgramConfig for ProgramConfig {
+        fn collateral_mint(&self) -> Pubkey {
+            COLLATERAL_MINT
+        }
+        fn lending_market(&self) -> Pubkey {
+            LENDING_MARKET_ACCOUNT
+        }
+        fn lending_market_authority(&self) -> Pubkey {
+            LENDING_MARKET_AUTHORITY
+        }
+        fn pyth_price_account(&self) -> Pubkey {
+            PYTH_PRICE_ACCOUNT
+        }
+        fn switchboard_price_account(&self) -> Pubkey {
+            SWITCHBOARD_PRICE_ACCOUNT
+        }
+        fn pyth_program_id(&self) -> Pubkey {
+            PYTH_PROGRAM_ID
+        }
+        fn switchboard_program_id(&self) -> Pubkey {
+            SWITCHBOARD_PROGRAM_ID
+        }
+        fn reserve(&self) -> Pubkey {
+            RESERVE_ACCOUNT
+        }
+        fn reserve_liquidity(&self) -> Pubkey {
+            RESERVE_LIQUIDITY_ACCOUNT
+        }
+        fn vault_collateral_account(&self) -> Pubkey {
+            COLLATERAL_TOKEN_ACCOUNT
+        }
+    }
 }
 
 /// bundles configuration information for the tulip usdc standalone vault
 pub mod tulip {
     use super::*;
+    use crate::config::strategy::traits::{StandaloneVaultProgramConfig, TulipProgramConfig};
 
     pub const TAG_STRING: &str = "tulip";
     pub const FARM_KEY: Farm = Farm::Lending {
         name: Lending::USDT,
     };
+
+    #[derive(Clone, Copy)]
+    pub struct ProgramConfig;
 
     /// address of the standalone vault itself
     pub const ACCOUNT: Pubkey = static_pubkey!("HC3ah2Z1VNBHjavM3o9uCWnPniy5g9VgHSzbuuBvTMzT");
@@ -380,16 +496,109 @@ pub mod tulip {
             lending_program: PROGRAM_ID,
         }
     }
+    impl StandaloneVaultProgramConfig for ProgramConfig {
+        fn account(&self) -> Pubkey {
+            ACCOUNT
+        }
+        fn pda(&self) -> Pubkey {
+            PDA
+        }
+        fn shares_mint(&self) -> Pubkey {
+            SHARES_MINT
+        }
+        fn underlying_compound_queue(&self) -> Pubkey {
+            UNDERLYING_COMPOUND_QUEUE
+        }
+        fn underlying_deposit_queue(&self) -> Pubkey {
+            UNDERLYING_DEPOSIT_QUEUE
+        }
+        fn underlying_withdraw_queue(&self) -> Pubkey {
+            UNDERLYING_WITHDRAW_QUEUE
+        }
+        fn underlying_mint(&self) -> Pubkey {
+            UNDERLYING_MINT
+        }
+        fn config_data_account(&self) -> Pubkey {
+            CONFIG_DATA_ACCOUNT
+        }
+        fn information_account(&self) -> Pubkey {
+            INFORMATION_ACCOUNT
+        }
+        fn program_id(&self) -> Pubkey {
+            PROGRAM_ID
+        }
+        fn solend_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::SolendProgramConfig>> {
+            None
+        }
+        fn tulip_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::TulipProgramConfig>> {
+            Some(Box::new(*self))
+        }
+        fn mango_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::MangoProgramConfig>> {
+            None
+        }
+        fn is_platform(&self, platform: Platform) -> bool {
+            matches!(platform, Platform::Tulip)
+        }
+        fn farm(&self) -> Farm {
+            FARM_KEY
+        }
+        fn tag(&self) -> &str {
+            TAG_STRING
+        }
+    }
+    impl TulipProgramConfig for ProgramConfig {
+        fn collateral_mint(&self) -> Pubkey {
+            COLLATERAL_MINT
+        }
+        fn lending_market(&self) -> Pubkey {
+            LENDING_MARKET_ACCOUNT
+        }
+        fn lending_market_authority(&self) -> Pubkey {
+            LENDING_MARKET_AUTHORITY
+        }
+        fn pyth_price_account(&self) -> Pubkey {
+            PYTH_PRICE_ACCOUNT
+        }
+        fn pyth_program_id(&self) -> Pubkey {
+            PYTH_PROGRAM_ID
+        }
+        fn reserve(&self) -> Pubkey {
+            RESERVE_ACCOUNT
+        }
+        fn reserve_liquidity(&self) -> Pubkey {
+            RESERVE_LIQUIDITY_ACCOUNT
+        }
+        fn vault_collateral_account(&self) -> Pubkey {
+            COLLATERAL_TOKEN_ACCOUNT
+        }
+    }
 }
 
 /// bundles configuration information for the mango usdc standalone vault
 pub mod mango {
-    use super::*;
+    use crate::config::strategy::{
+        traits::{MangoProgramConfig, StandaloneVaultProgramConfig},
+        withdraw::PlatformConfigAddresses,
+        Platform,
+    };
+
+    use anchor_lang::solana_program::{self, pubkey::Pubkey};
+    use static_pubkey::static_pubkey;
+    use tulipv2_sdk_farms::{lending::Lending, Farm};
 
     pub const TAG_STRING: &str = "mango";
     pub const FARM_KEY: Farm = Farm::Lending {
         name: Lending::USDT,
     };
+
+    #[derive(Clone, Copy)]
+    pub struct ProgramConfig;
 
     /// address of the standalone vault itself
     pub const ACCOUNT: Pubkey = static_pubkey!("3Y9yqi2K4E4zsthNj2YP4sip59azSHA4qhwMkLxtokFZ");
@@ -442,6 +651,85 @@ pub mod mango {
             shares_mint: SHARES_MINT,
             underlying_deposit_queue: UNDERLYING_DEPOSIT_QUEUE,
             lending_program: PROGRAM_ID,
+        }
+    }
+    impl StandaloneVaultProgramConfig for ProgramConfig {
+        fn account(&self) -> Pubkey {
+            ACCOUNT
+        }
+        fn pda(&self) -> Pubkey {
+            PDA
+        }
+        fn shares_mint(&self) -> Pubkey {
+            SHARES_MINT
+        }
+        fn underlying_compound_queue(&self) -> Pubkey {
+            UNDERLYING_COMPOUND_QUEUE
+        }
+        fn underlying_deposit_queue(&self) -> Pubkey {
+            UNDERLYING_DEPOSIT_QUEUE
+        }
+        fn underlying_withdraw_queue(&self) -> Pubkey {
+            UNDERLYING_WITHDRAW_QUEUE
+        }
+        fn underlying_mint(&self) -> Pubkey {
+            UNDERLYING_MINT
+        }
+        fn config_data_account(&self) -> Pubkey {
+            CONFIG_DATA_ACCOUNT
+        }
+        fn information_account(&self) -> Pubkey {
+            INFORMATION_ACCOUNT
+        }
+        fn program_id(&self) -> Pubkey {
+            PROGRAM_ID
+        }
+        fn solend_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::SolendProgramConfig>> {
+            None
+        }
+        fn tulip_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::TulipProgramConfig>> {
+            None
+        }
+        fn mango_config(
+            &self,
+        ) -> Option<Box<dyn crate::config::strategy::traits::MangoProgramConfig>> {
+            Some(Box::new(*self))
+        }
+        fn is_platform(&self, platform: Platform) -> bool {
+            matches!(platform, Platform::MangoV3)
+        }
+        fn farm(&self) -> Farm {
+            FARM_KEY
+        }
+        fn tag(&self) -> &str {
+            TAG_STRING
+        }
+    }
+    impl MangoProgramConfig for ProgramConfig {
+        fn cache(&self) -> Pubkey {
+            CACHE
+        }
+        fn group(&self) -> Pubkey {
+            GROUP
+        }
+        fn group_signer(&self) -> Pubkey {
+            GROUP_SIGNER
+        }
+        fn group_token_account(&self) -> Pubkey {
+            GROUP_TOKEN_ACCOUNT
+        }
+        fn root_bank(&self) -> Pubkey {
+            ROOT_BANK
+        }
+        fn node_bank(&self) -> Pubkey {
+            NODE_BANK
+        }
+        fn optimizer_mango_account(&self) -> Pubkey {
+            OPTIMIZER_MANGO_ACCOUNT
         }
     }
 }

--- a/common/src/config/strategy/usdt.rs
+++ b/common/src/config/strategy/usdt.rs
@@ -18,6 +18,8 @@ use crate::config::deposit_tracking::issue_shares::DepositAddressesPermissioned;
 /// bundles configuration information for the usdc lending optimizer multi deposit vault
 pub mod multi_deposit {
 
+    use crate::config::strategy::traits::MultiVaultProgramConfig;
+
     use super::*;
 
     /// empty struct used to implement the various traits used
@@ -159,6 +161,64 @@ pub mod multi_deposit {
                 super::mango::GROUP_TOKEN_ACCOUNT,
                 super::mango::GROUP_SIGNER,
             ]
+        }
+    }
+    impl MultiVaultProgramConfig for ProgramConfig {
+        fn account(&self, ) -> Pubkey {
+            ACCOUNT
+        }
+        fn pda(&self, ) -> Pubkey {
+            PDA
+        }
+        fn shares_mint(&self, ) -> Pubkey {
+            SHARES_MINT
+        }
+        fn underlying_compound_queue(&self, ) -> Pubkey {
+            UNDERLYING_COMPOUND_QUEUE
+        }
+        fn underlying_deposit_queue(&self, ) -> Pubkey {
+            UNDERLYING_DEPOSIT_QUEUE
+        }
+        fn underlying_withdraw_queue(&self, ) -> Pubkey {
+            UNDERLYING_WITHDRAW_QUEUE
+        }
+        fn underlying_mint(&self, ) -> Pubkey {
+            UNDERLYING_MINT
+        }
+        fn rebalance_state_transition(&self, ) -> Pubkey {
+            REBALANCE_STATE_TRANSITION
+        }
+        fn rebalance_state_transition_underlying(&self, ) -> Pubkey {
+            REBALANCE_STATE_TRANSITION_UNDERLYING
+        }
+        fn optimizer_shares_account(&self, platform: Platform) -> Pubkey {
+            match platform {
+                Platform::MangoV3 => MANGO_OPTIMIZER_SHARES_ACCOUNT,
+                Platform::Solend => SOLEND_OPTIMIZER_SHARES_ACCOUNT,
+                Platform::Tulip => TULIP_OPTIMIZER_SHARES_ACCOUNT
+            }
+        }
+        fn issue_shares(&self, user: Pubkey) -> Box<dyn IssueShares> {
+            Box::new(ProgramConfig::issue_shares_ix(user))
+        }
+        fn permissioned_issue_shares(&self, user: Pubkey) -> Box<dyn IssueShares> {
+            Box::new(ProgramConfig::permissioned_issue_shares_ix(user))
+        }
+        fn register_deposit_tracking(&self, user: Pubkey) -> Box<dyn RegisterDepositTracking> {
+            Box::new(ProgramConfig::register_deposit_tracking_ix(user))
+        }
+        fn withdraw_deposit_tracking(&self, user: Pubkey) -> Box<dyn WithdrawDepositTracking> {
+            Box::new( ProgramConfig::withdraw_deposit_tracking_ix(user))
+        }
+        fn withdraw_multi_deposit_optimizer_vault(&self, user: Pubkey, platform: Platform) -> std::result::Result<Box<dyn WithdrawMultiOptimizerVault>, std::io::Error> {
+            Ok(ProgramConfig::withdraw_multi_deposit_optimizer_vault(user, platform)?)
+        }
+        fn remaining_accounts(&self, platform: Platform) -> Vec<Pubkey> {
+            match platform {
+                Platform::MangoV3 => ProgramConfig::get_mango_remaining_accounts().to_vec(),
+                Platform::Solend => ProgramConfig::get_solend_remaining_accounts().to_vec(),
+                Platform::Tulip => ProgramConfig::get_tulip_remaining_accounts().to_vec(),
+            }
         }
     }
 }

--- a/examples/programs/examples/src/lib.rs
+++ b/examples/programs/examples/src/lib.rs
@@ -616,15 +616,19 @@ pub mod examples {
         ctx: Context<WithdrawMangoMultiDepositOptimizerVault>,
         amount: u64,
     ) -> Result<()> {
+        use tulipv2_sdk_common::config::strategy::{Platform, StrategyVaults};
         // you must scope the instruction creation function the way this is done
         // otherwise stack size will be blown, as the size of the `withdraw_trait`
         // and the instruction itself can't be on the stack when the instruction is
         // invoked through cpi
         let ix = {
-            let withdraw_trait = tulipv2_sdk_common::config::strategy::usdc::multi_deposit::ProgramConfig::withdraw_multi_deposit_optimizer_vault(
-                *ctx.accounts.common_data.authority.key,
-                tulipv2_sdk_common::config::strategy::Platform::MangoV3,
-            ).unwrap();
+            let conf = StrategyVaults::USDCv1.multi_deposit_config();
+            let withdraw_trait = conf
+                .withdraw_multi_deposit_optimizer_vault(
+                    *ctx.accounts.common_data.authority.key,
+                    Platform::MangoV3,
+                )
+                .unwrap();
             let ix = withdraw_trait.instruction(amount).unwrap();
             ix
         };
@@ -688,15 +692,19 @@ pub mod examples {
         ctx: Context<'a, 'b, 'c, 'info, WithdrawSolendMultiDepositOptimizerVault<'info>>,
         amount: u64,
     ) -> Result<()> {
+        use tulipv2_sdk_common::config::strategy::{Platform, StrategyVaults};
         // you must scope the instruction creation function the way this is done
         // otherwise stack size will be blown, as the size of the `withdraw_trait`
         // and the instruction itself can't be on the stack when the instruction is
         // invoked through cpi
         let ix = {
-            let withdraw_trait = tulipv2_sdk_common::config::strategy::usdc::multi_deposit::ProgramConfig::withdraw_multi_deposit_optimizer_vault(
-                *ctx.accounts.common_data.authority.key,
-                tulipv2_sdk_common::config::strategy::Platform::Solend,
-            ).unwrap();
+            let conf = StrategyVaults::USDCv1.multi_deposit_config();
+            let withdraw_trait = conf
+                .withdraw_multi_deposit_optimizer_vault(
+                    *ctx.accounts.common_data.authority.key,
+                    Platform::Solend,
+                )
+                .unwrap();
             let ix = withdraw_trait.instruction(amount).unwrap();
             ix
         };
@@ -769,15 +777,19 @@ pub mod examples {
         ctx: Context<'a, 'b, 'c, 'info, WithdrawTulipMultiDepositOptimizerVault<'info>>,
         amount: u64,
     ) -> Result<()> {
+        use tulipv2_sdk_common::config::strategy::{Platform, StrategyVaults};
         // you must scope the instruction creation function the way this is done
         // otherwise stack size will be blown, as the size of the `withdraw_trait`
         // and the instruction itself can't be on the stack when the instruction is
         // invoked through cpi
         let ix = {
-            let withdraw_trait = tulipv2_sdk_common::config::strategy::usdc::multi_deposit::ProgramConfig::withdraw_multi_deposit_optimizer_vault(
-                *ctx.accounts.common_data.authority.key,
-                tulipv2_sdk_common::config::strategy::Platform::Tulip,
-            ).unwrap();
+            let conf = StrategyVaults::USDCv1.multi_deposit_config();
+            let withdraw_trait = conf
+                .withdraw_multi_deposit_optimizer_vault(
+                    *ctx.accounts.common_data.authority.key,
+                    Platform::Tulip,
+                )
+                .unwrap();
             let ix = withdraw_trait.instruction(amount).unwrap();
             ix
         };
@@ -1733,7 +1745,8 @@ pub mod examples {
                     None, // for shares issuance we dont need to derive these values
                     None, // for shares issuance we dont need to derive these values
                 );
-                let issue_trait = raydium_config.permissioned_issue_shares(ctx.accounts.authority.key());
+                let issue_trait =
+                    raydium_config.permissioned_issue_shares(ctx.accounts.authority.key());
                 anchor_lang::solana_program::program::invoke(
                     &issue_trait
                         .instruction(
@@ -1780,7 +1793,6 @@ pub mod examples {
         }
         Ok(())
     }
-    
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
@@ -2805,7 +2817,6 @@ pub struct WithdrawOrcaFarm<'info> {
     pub user_farm: AccountInfo<'info>, // 10
     */
 }
-
 
 #[derive(Accounts)]
 pub struct PermissionedIssueSharesInstruction<'info> {

--- a/examples/programs/examples/src/lib.rs
+++ b/examples/programs/examples/src/lib.rs
@@ -5,6 +5,7 @@ use tulipv2_sdk_common::config::deposit_tracking::traits::IssueShares;
 use tulipv2_sdk_common::config::deposit_tracking::traits::RegisterDepositTracking;
 use tulipv2_sdk_common::config::deposit_tracking::traits::WithdrawDepositTracking;
 use tulipv2_sdk_common::config::strategy::traits::WithdrawMultiOptimizerVault;
+use tulipv2_sdk_common::config::strategy::{Platform, StrategyVaults};
 use tulipv2_sdk_common::msg_panic;
 use tulipv2_sdk_farms::Farm;
 use tulipv2_sdk_vaults::instructions::{
@@ -228,15 +229,13 @@ pub mod examples {
             tulipv2_sdk_farms::Farm::Lending {
                 name: tulipv2_sdk_farms::lending::Lending::MULTI_DEPOSIT,
             } => {
-                let registration_trait = tulipv2_sdk_common::config::strategy::usdc::multi_deposit::ProgramConfig::register_deposit_tracking_ix(
-                        *ctx.accounts.authority.key,
-                    );
+                let strat_vault: StrategyVaults =
+                    tulipv2_sdk_vaults::into_strategy_vault(&ctx.accounts.vault);
+                let conf = strat_vault.multi_deposit_config();
+                let registration_trait =
+                    conf.register_deposit_tracking(*ctx.accounts.authority.key);
                 anchor_lang::solana_program::program::invoke(
-                    &registration_trait
-                        .instruction(tulipv2_sdk_farms::Farm::Lending {
-                            name: tulipv2_sdk_farms::lending::Lending::MULTI_DEPOSIT,
-                        })
-                        .unwrap(),
+                    &registration_trait.instruction(conf.farm()).unwrap(),
                     &[
                         ctx.accounts.authority.clone(),
                         ctx.accounts.vault.clone(),
@@ -407,12 +406,12 @@ pub mod examples {
             tulipv2_sdk_farms::Farm::Lending {
                 name: tulipv2_sdk_farms::lending::Lending::MULTI_DEPOSIT,
             } => {
-                let issue_trait = tulipv2_sdk_common::config::strategy::usdc::multi_deposit::ProgramConfig::issue_shares_ix(
-                    *ctx.accounts.authority.key,
-                );
-
+                let strat_vault: StrategyVaults =
+                    tulipv2_sdk_vaults::into_strategy_vault(&ctx.accounts.vault);
+                let conf = strat_vault.multi_deposit_config();
+                let issue_trait = conf.issue_shares(*ctx.accounts.authority.key);
                 anchor_lang::solana_program::program::invoke(
-                    &issue_trait.instruction(farm_type.into(), amount).unwrap(),
+                    &issue_trait.instruction(conf.farm(), amount).unwrap(),
                     &[
                         ctx.accounts.authority.clone(),
                         ctx.accounts.vault.clone(),
@@ -586,13 +585,12 @@ pub mod examples {
             tulipv2_sdk_farms::Farm::Lending {
                 name: tulipv2_sdk_farms::lending::Lending::MULTI_DEPOSIT,
             } => {
-                let withdraw_trait = tulipv2_sdk_common::config::strategy::usdc::multi_deposit::ProgramConfig::withdraw_deposit_tracking_ix(
-                    *ctx.accounts.authority.key,
-                );
+                let strat_vault: StrategyVaults =
+                    tulipv2_sdk_vaults::into_strategy_vault(&ctx.accounts.vault);
+                let conf = strat_vault.multi_deposit_config();
+                let withdraw_trait = conf.withdraw_deposit_tracking(*ctx.accounts.authority.key);
                 anchor_lang::solana_program::program::invoke(
-                    &withdraw_trait
-                        .instruction(amount, farm_type.into())
-                        .unwrap(),
+                    &withdraw_trait.instruction(amount, conf.farm()).unwrap(),
                     &[
                         ctx.accounts.authority.clone(),
                         ctx.accounts.clock.to_account_info(),
@@ -622,7 +620,9 @@ pub mod examples {
         // and the instruction itself can't be on the stack when the instruction is
         // invoked through cpi
         let ix = {
-            let conf = StrategyVaults::USDCv1.multi_deposit_config();
+            let strat_vault: StrategyVaults =
+                tulipv2_sdk_vaults::into_strategy_vault(&ctx.accounts.common_data.multi_vault);
+            let conf = strat_vault.multi_deposit_config();
             let withdraw_trait = conf
                 .withdraw_multi_deposit_optimizer_vault(
                     *ctx.accounts.common_data.authority.key,
@@ -698,7 +698,9 @@ pub mod examples {
         // and the instruction itself can't be on the stack when the instruction is
         // invoked through cpi
         let ix = {
-            let conf = StrategyVaults::USDCv1.multi_deposit_config();
+            let strat_vault: StrategyVaults =
+                tulipv2_sdk_vaults::into_strategy_vault(&ctx.accounts.common_data.multi_vault);
+            let conf = strat_vault.multi_deposit_config();
             let withdraw_trait = conf
                 .withdraw_multi_deposit_optimizer_vault(
                     *ctx.accounts.common_data.authority.key,
@@ -783,7 +785,9 @@ pub mod examples {
         // and the instruction itself can't be on the stack when the instruction is
         // invoked through cpi
         let ix = {
-            let conf = StrategyVaults::USDCv1.multi_deposit_config();
+            let strat_vault: StrategyVaults =
+                tulipv2_sdk_vaults::into_strategy_vault(&ctx.accounts.common_data.multi_vault);
+            let conf = strat_vault.multi_deposit_config();
             let withdraw_trait = conf
                 .withdraw_multi_deposit_optimizer_vault(
                     *ctx.accounts.common_data.authority.key,
@@ -1771,12 +1775,12 @@ pub mod examples {
             tulipv2_sdk_farms::Farm::Lending {
                 name: tulipv2_sdk_farms::lending::Lending::MULTI_DEPOSIT,
             } => {
-                let issue_trait = tulipv2_sdk_common::config::strategy::usdc::multi_deposit::ProgramConfig::permissioned_issue_shares_ix(
-                    *ctx.accounts.authority.key,
-                );
+                // assumes the vault is a usdc strategy vault
+                let conf = StrategyVaults::USDCv1.multi_deposit_config();
+                let issue_trait = conf.permissioned_issue_shares(*ctx.accounts.authority.key);
 
                 anchor_lang::solana_program::program::invoke(
-                    &issue_trait.instruction(farm_type.into(), amount).unwrap(),
+                    &issue_trait.instruction(conf.farm(), amount).unwrap(),
                     &[
                         ctx.accounts.authority.clone(),
                         ctx.accounts.vault.clone(),

--- a/vaults/src/lib.rs
+++ b/vaults/src/lib.rs
@@ -2,8 +2,42 @@ pub mod accounts;
 pub mod config;
 pub mod instructions;
 
-use anchor_lang::solana_program::{self, pubkey::Pubkey};
+use accounts::{multi_optimizer::MultiDepositOptimizerV1, Base};
+use anchor_lang::{
+    prelude::{AccountInfo, AccountLoader},
+    solana_program::{self, pubkey::Pubkey},
+};
 use static_pubkey::static_pubkey;
+use tulipv2_sdk_common::{config::strategy::StrategyVaults, tag::tag_to_str};
+use tulipv2_sdk_farms::{lending::Lending, Farm};
 
 pub const ID: Pubkey = static_pubkey!("TLPv2tuSVvn3fSk8RgW3yPddkp5oFivzZV3rA9hQxtX");
 pub const MANAGEMENT: Pubkey = tulipv2_sdk_common::config::V2_MANAGEMENT;
+
+/// attempts to parse an account into a StrategyVault type, requires
+/// that the account is a v2 vault account, and that it's of type MultiDepositOptimizerV1
+#[inline(always)]
+pub fn into_strategy_vault<'info>(account: &AccountInfo<'info>) -> StrategyVaults {
+    let loader: AccountLoader<MultiDepositOptimizerV1> = AccountLoader::try_from(account).unwrap();
+    {
+        let vault = loader.load().unwrap();
+        let farm = vault.farm();
+        match farm {
+            Farm::Lending { name } => match name {
+                Lending::MULTI_DEPOSIT => {
+                    let mut tag = tag_to_str(&vault.base.tag);
+                    tag.make_ascii_lowercase();
+                    match tag.as_str() {
+                        "usdcv1" => StrategyVaults::USDCv1,
+                        "usdtv1" => StrategyVaults::USDTv1,
+                        "solv1" => StrategyVaults::SOLv1,
+                        "rayv1" => StrategyVaults::RAYv1,
+                        _ => unimplemented!(),
+                    }
+                }
+                _ => unimplemented!(),
+            },
+            _ => unimplemented!(),
+        }
+    }
+}

--- a/vaults/src/lib.rs
+++ b/vaults/src/lib.rs
@@ -41,3 +41,59 @@ pub fn into_strategy_vault<'info>(account: &AccountInfo<'info>) -> StrategyVault
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use anchor_lang::solana_program::{self, pubkey::Pubkey, account_info::IntoAccountInfo};
+    use solana_client::rpc_client::RpcClient;
+    use static_pubkey::static_pubkey;
+    #[test]
+    fn test_into_strategy_vault_usdcv1() {
+        let vault_key = static_pubkey!("3wPiV9inTGexMZjp6x5Amqwp2sRNtpSheG8Hbv2rgq8W");
+        let rpc = RpcClient::new("https://ssc-dao.genesysgo.net".to_string());
+        let account = rpc.get_account(&vault_key).unwrap();
+
+        let mut acct_tup = (vault_key, account);
+        let mut acct = acct_tup.into_account_info();
+
+        let strat_vault = into_strategy_vault(&acct);
+        assert!(strat_vault.eq(&StrategyVaults::USDCv1));
+    }
+    #[test]
+    fn test_into_strategy_vault_usdtv1() {
+        let vault_key = static_pubkey!("BBRkN5paHbHLku4KrZMN8Mc5U3Ygasd4v2FtxdwG7F8F");
+        let rpc = RpcClient::new("https://ssc-dao.genesysgo.net".to_string());
+        let account = rpc.get_account(&vault_key).unwrap();
+
+        let mut acct_tup = (vault_key, account);
+        let mut acct = acct_tup.into_account_info();
+
+        let strat_vault = into_strategy_vault(&acct);
+        assert!(strat_vault.eq(&StrategyVaults::USDTv1));
+    }
+    #[test]
+    fn test_into_strategy_vault_rayv1() {
+        let vault_key = static_pubkey!("EH1iQnhDqQpHsVJWLw8oC1ehDqVaPGh7JH6ctG4dAQ2d");
+        let rpc = RpcClient::new("https://ssc-dao.genesysgo.net".to_string());
+        let account = rpc.get_account(&vault_key).unwrap();
+
+        let mut acct_tup = (vault_key, account);
+        let mut acct = acct_tup.into_account_info();
+
+        let strat_vault = into_strategy_vault(&acct);
+        assert!(strat_vault.eq(&StrategyVaults::RAYv1));
+    }
+    #[test]
+    fn test_into_strategy_vault_solv1() {
+        let vault_key = static_pubkey!("2WNw7tW2G54UCXN726S5tR9XutSEDeMf7xamidQtWszK");
+        let rpc = RpcClient::new("https://ssc-dao.genesysgo.net".to_string());
+        let account = rpc.get_account(&vault_key).unwrap();
+
+        let mut acct_tup = (vault_key, account);
+        let mut acct = acct_tup.into_account_info();
+
+        let strat_vault = into_strategy_vault(&acct);
+        assert!(strat_vault.eq(&StrategyVaults::SOLv1));
+    }
+}


### PR DESCRIPTION
# Overview

Adds trait based configuration for multi deposit / strategy vaults to enable easier integration, and reduce boilerplate code.

Before:

```rust
                // requires specific code due to namespaces for each strategy vault
                let registration_trait = tulipv2_sdk_common::config::strategy::usdc::multi_deposit::ProgramConfig::register_deposit_tracking_ix(
                        *ctx.accounts.authority.key,
                    );
```

Now

```rust
                // can be reused for any strategy vault avoiding specific code, long namespaces, etc..
                let strat_vault: StrategyVaults =
                    tulipv2_sdk_vaults::into_strategy_vault(&ctx.accounts.vault);
                let conf = strat_vault.multi_deposit_config();
                let registration_trait =
                    conf.register_deposit_tracking(*ctx.accounts.authority.key);
```

# Changes

* Adds a `MultiVaultProgramConfig` trait which can be used to access the main configuration  for a multi deposit vault, which in turn can be used to access configurations for standalone vaults
* Adds a `StandaloneVaultProgramConfig` trait which can be used to access configuration for a standalone vault
* Adds a `SolendProgramConfig` trait which can be used to access solend configuration used by solend standalone vaults
* Adds a `MangoProgramConfig` trait which can be used to access mango configuration used by mango standalone vaults
* Adds a `TulipProgramConfig` trait which can be used to access tulip configuration used by tulip standalone vaults
* Adds a `StrategyVaults` enum 
* Updates example program to use the newly added traits